### PR TITLE
Ignore restart annotation when looking for 1Password annotations

### DIFF
--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -99,7 +99,7 @@ func (r *ReconcileDeployment) Reconcile(request reconcile.Request) (reconcile.Re
 
 	annotations, annotationsFound := op.GetAnnotationsForDeployment(deployment, r.opAnnotationRegExp)
 	if !annotationsFound {
-		reqLogger.Info("No One Password Annotations found")
+		reqLogger.Info("No 1Password Annotations found")
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/onepassword/annotations.go
+++ b/pkg/onepassword/annotations.go
@@ -34,7 +34,7 @@ func GetAnnotationsForDeployment(deployment *appsv1.Deployment, regex *regexp.Re
 func FilterAnnotations(annotations map[string]string, regex *regexp.Regexp) map[string]string {
 	filteredAnnotations := make(map[string]string)
 	for key, value := range annotations {
-		if regex.MatchString(key) {
+		if regex.MatchString(key) && key != RestartAnnotation {
 			filteredAnnotations[key] = value
 		}
 	}


### PR DESCRIPTION
Fixes bug where deployment controller assumed deployments with restart annotations required a secret to be created on deployment.