### PR TITLE
Upgrading apiextensions.k8s.io/v1beta apiversion from the operator custom resource

### DIFF
--- a/deploy/crds/onepassword.com_onepassworditems_crd.yaml
+++ b/deploy/crds/onepassword.com_onepassworditems_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: onepassworditems.onepassword.com
@@ -10,36 +10,33 @@ spec:
     plural: onepassworditems
     singular: onepassworditem
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: OnePasswordItem is the Schema for the onepassworditems API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: OnePasswordItemSpec defines the desired state of OnePasswordItem
-          properties:
-            item_path:
-              type: string
-          type: object
-        status:
-          description: OnePasswordItemStatus defines the observed state of OnePasswordItem
-          type: object
-      type: object
-  version: v1
   versions:
   - name: v1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        description: OnePasswordItem is the Schema for the onepassworditems API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OnePasswordItemSpec defines the desired state of OnePasswordItem
+            properties:
+              itemPath:
+                type: string
+            type: object
+          status:
+            description: OnePasswordItemStatus defines the observed state of OnePasswordItem
+            type: object
+        type: object


### PR DESCRIPTION
The api version (apiextensions.k8s.io/v1beta) being used by the one password connect custom resource was deprecated. This change upgrades the the version `apiextensions.k8s.io/v1`