### PR TITLE
Adding configuration for auto rolling restart on deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The 1Password Connect Kubernetes Operator provides the ability to integrate Kube
 
 The 1Password Connect Kubernetes Operator also allows for Kubernetes Secrets to be composed from a 1Password Item through annotation of an Item Path on a deployment.
 
-The 1Password Connect Kubernetes Operator will continually check for updates from 1Password for any Kubernetes Secret that it has generated. If a Kubernetes Secret is updated, any Deployment using that secret will be automatically restarted.
+The 1Password Connect Kubernetes Operator will continually check for updates from 1Password for any Kubernetes Secret that it has generated. If a Kubernetes Secret is updated, any Deployment using that secret can be automatically restarted.
 
 ## Setup
 
@@ -85,6 +85,7 @@ To further configure the 1Password Kubernetes Operator the Following Environment
 - **OP_CONNECT_HOST** (required): Specifies the host name within Kubernetes in which to access the 1Password Connect.
 - **POLLING_INTERVAL** (default: 600)**:** The number of seconds the 1Password Kubernetes Operator will wait before checking for updates from 1Password Connect.
 - **MANAGE_CONNECT** (default: false): If set to true, on deployment of the operator, a default configuration of the OnePassword Connect Service will be deployed to the `default` namespace.
+- **AUTO_RESTART** (default: false): If set to true, the operator will restart any deployment using a secret from 1Password Connect. This can be overwritten by namespace, deployment, or individual secret. More details on AUTO_RESTART can be found in the ["Configuring Automatic Rolling Restarts of Deployments"](#configuring-automatic-rolling-restarts-of-deployments) section.
 
 Apply the deployment file:
 
@@ -135,8 +136,7 @@ Applying this yaml file will create a Kubernetes Secret with the name `{secret_n
 
 Note: Deleting the Deployment that you've created will automatically delete the created Kubernetes Secret only if the deployment is still annotated with `onepasswordoperator./item-path` and `onepasswordoperator/item-name` and no other deployment is using the secret.
 
-If a 1Password Item that is linked to a Kubernetes Secret is updated within the `POLLING_INTERVAL` the associated Kubernetes Secret will be updated. Furthermore, any deployments using that secret will be given a rolling restart.
-
+If a 1Password Item that is linked to a Kubernetes Secret is updated within the POLLING_INTERVAL the associated Kubernetes Secret will be updated. However, if you do not want a specific secret to be updated you can add the tag `onepasswordconnectoperator:ignore_secret` to the item stored in 1Password. While this tag is in place, any updates made to an item will not trigger an update to the associated secret in Kubernetes.
 
 ---
 **NOTE**
@@ -144,6 +144,38 @@ If a 1Password Item that is linked to a Kubernetes Secret is updated within the 
 If multiple 1Password vaults/items have the same `title` when using a title in the access path, the desired action will be performed on the oldest vault/item. Furthermore, titles that include white space characters cannot be used.
 
 ---
+
+### Configuring Automatic Rolling Restarts of Deployments
+
+If a 1Password Item that is linked to a Kubernetes Secret is updated, any deployments configured to `auto_restart` AND are using that secret will be given a rolling restart the next time 1Password Connect is polled for updates.
+
+There are many levels of granularity on which to configure auto restarts on deployments: at the operator level, per-namespace, or per-deployment.
+
+**On the operator**: This method allows for managing auto restarts on all deployments within the namespaces watched by operator. Auto restarts can be enabled by setting the environemnt variable  `AUTO_RESTART` to true. If the value is not set, the operator will default this value to false.
+
+**Per Namespace**: This method allows for managing auto restarts on all deployments within a namespace. Auto restarts can by managed by setting the annotation `onepasswordoperator/auto_restart` to either `true` or `false` on the desired namespace. An example of this is shown below:
+```yaml
+# enabled auto restarts for all deployments within a namespace unless overwritten within a deployment
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "example-namespace"
+  onepasswordoperator/auto_restart: "true"
+```
+If the value is not set, the auto reset settings on the operator will be used. This value can be overwritten by deployment.
+
+**Per Deployment**
+This method allows for managing auto restarts on a given deployment. Auto restarts can by managed by setting the annotation `onepasswordoperator/auto_restart` to either `true` or `false` on the desired deployment. An example of this is shown below:
+```yaml
+# enabled auto restarts for the deployment
+apiVersion: v1
+kind: Deployment
+metadata:
+  name: "example-deployment"
+  onepasswordoperator/auto_restart: "true"
+```
+If the value is not set, the auto reset settings on the namespace will be used.
+
 ## Development
 
 ### Creating a Docker image

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -42,6 +42,7 @@ import (
 
 const envPollingIntervalVariable = "POLLING_INTERVAL"
 const manageConnect = "MANAGE_CONNECT"
+const restartDeploymentsEnvVariable = "AUTO_RESTART"
 const defaultPollingInterval = 600
 
 // Change below variables to serve metrics on different host or port.
@@ -165,7 +166,7 @@ func main() {
 	addMetrics(ctx, cfg)
 
 	// Setup update secrets task
-	updatedSecretsPoller := op.NewManager(mgr.GetClient(), opConnectClient)
+	updatedSecretsPoller := op.NewManager(mgr.GetClient(), opConnectClient, shouldAutoRestartDeployments())
 	done := make(chan bool)
 	ticker := time.NewTicker(getPollingIntervalForUpdatingSecrets())
 	go func() {
@@ -281,6 +282,19 @@ func shouldManageConnect() bool {
 			os.Exit(1)
 		}
 		return shouldManageConnectBool
+	}
+	return false
+}
+
+func shouldAutoRestartDeployments() bool {
+	shouldAutoRestartDeployments, found := os.LookupEnv(restartDeploymentsEnvVariable)
+	if found {
+		shouldAutoRestartDeploymentsBool, err := strconv.ParseBool(strings.ToLower(shouldAutoRestartDeployments))
+		if err != nil {
+			log.Error(err, "")
+			os.Exit(1)
+		}
+		return shouldAutoRestartDeploymentsBool
 	}
 	return false
 }

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -35,3 +35,5 @@ spec:
                 secretKeyRef:
                   name: onepassword-token
                   key: token
+            - name: AUTO_RESTART
+              value: "false"

--- a/deploy/operator_multi_namespace_example.yaml
+++ b/deploy/operator_multi_namespace_example.yaml
@@ -16,9 +16,7 @@ spec:
       containers:
         - name: onepassword-connect-operator
           image: 1password/onepassword-operator
-          command:
-          - onepassword-connect-operator
-          imagePullPolicy: Never
+          command: ["/manager"]
           env:
             - name: WATCH_NAMESPACE
               value: "default,development"
@@ -29,7 +27,7 @@ spec:
             - name: OPERATOR_NAME
               value: "onepassword-connect-operator"
             - name: OP_CONNECT_HOST
-              value: "http://secret-service:8080"
+              value: "http://onepassword-connect:8080"
             - name: POLLING_INTERVAL
               value: "10"
             - name: OP_CONNECT_TOKEN
@@ -37,3 +35,5 @@ spec:
                 secretKeyRef:
                   name: onepassword-token
                   key: token
+            - name: AUTO_RESTART
+              value: "false"

--- a/deploy/permissions.yaml
+++ b/deploy/permissions.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: onepassword-connect-operator
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: onepassword-connect-operator-default
@@ -13,12 +13,12 @@ subjects:
   name: onepassword-connect-operator
   namespace: default
 roleRef:
-  kind: Role
+  kind: ClusterRole
   name: onepassword-connect-operator
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   creationTimestamp: null
   name: onepassword-connect-operator
@@ -34,6 +34,7 @@ rules:
   - events
   - configmaps
   - secrets
+  - namespaces
   verbs:
   - create
   - delete

--- a/deploy/permissions_multi_namespace_example.yaml
+++ b/deploy/permissions_multi_namespace_example.yaml
@@ -3,7 +3,7 @@ kind: ServiceAccount
 metadata:
   name: onepassword-connect-operator
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: onepassword-connect-operator-default
@@ -17,7 +17,7 @@ roleRef:
   name: onepassword-connect-operator
   apiGroup: rbac.authorization.k8s.io
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: onepassword-connect-operator-development
@@ -48,6 +48,7 @@ rules:
   - events
   - configmaps
   - secrets
+  - namespaces
   verbs:
   - create
   - delete

--- a/go.sum
+++ b/go.sum
@@ -1447,6 +1447,7 @@ k8s.io/apimachinery v0.18.2/go.mod h1:9SnR/e11v5IbyPCGbvJViimtJ0SwHG4nfZFjU77ftc
 k8s.io/apimachinery v0.19.2 h1:5Gy9vQpAGTKHPVOh5c4plE274X8D/6cuEiTO2zve7tc=
 k8s.io/apimachinery v0.19.3 h1:bpIQXlKjB4cB/oNpnNnV+BybGPR7iP5oYpsOTEJ4hgc=
 k8s.io/apimachinery v0.20.1 h1:LAhz8pKbgR8tUwn7boK+b2HZdt7MiTu2mkYtFMUjTRQ=
+k8s.io/apimachinery v0.20.2 h1:hFx6Sbt1oG0n6DZ+g4bFt5f6BoMkOjKWsQFu077M3Vg=
 k8s.io/apiserver v0.0.0-20190918160949-bfa5e2e684ad/go.mod h1:XPCXEwhjaFN29a8NldXA901ElnKeKLrLtREO9ZhFyhg=
 k8s.io/apiserver v0.0.0-20191122221311-9d521947b1e1/go.mod h1:RbsZY5zzBIWnz4KbctZsTVjwIuOpTp4Z8oCgFHN4kZQ=
 k8s.io/apiserver v0.16.7/go.mod h1:/5zSatF30/L9zYfMTl55jzzOnx7r/gGv5a5wtRp8yAw=

--- a/pkg/onepassword/annotations.go
+++ b/pkg/onepassword/annotations.go
@@ -7,11 +7,12 @@ import (
 )
 
 const (
-	OnepasswordPrefix  = "onepasswordoperator"
-	ItemPathAnnotation = OnepasswordPrefix + "/item-path"
-	NameAnnotation     = OnepasswordPrefix + "/item-name"
-	VersionAnnotation  = OnepasswordPrefix + "/item-version"
-	RestartAnnotation  = OnepasswordPrefix + "/lastRestarted"
+	OnepasswordPrefix            = "onepasswordoperator"
+	ItemPathAnnotation           = OnepasswordPrefix + "/item-path"
+	NameAnnotation               = OnepasswordPrefix + "/item-name"
+	VersionAnnotation            = OnepasswordPrefix + "/item-version"
+	RestartAnnotation            = OnepasswordPrefix + "/lastRestarted"
+	RestartDeploymentsAnnotation = OnepasswordPrefix + "/auto_restart"
 )
 
 func GetAnnotationsForDeployment(deployment *appsv1.Deployment, regex *regexp.Regexp) (map[string]string, bool) {
@@ -34,7 +35,7 @@ func GetAnnotationsForDeployment(deployment *appsv1.Deployment, regex *regexp.Re
 func FilterAnnotations(annotations map[string]string, regex *regexp.Regexp) map[string]string {
 	filteredAnnotations := make(map[string]string)
 	for key, value := range annotations {
-		if regex.MatchString(key) && key != RestartAnnotation {
+		if regex.MatchString(key) && key != RestartAnnotation && key != RestartDeploymentsAnnotation {
 			filteredAnnotations[key] = value
 		}
 	}


### PR DESCRIPTION
- Locked secrets will not trigger rolling restarts of deployments
- Configure restart of deployments via operator environment variables, namespace annotations, or deployment annotations
- Updating permissions examples to include the ability to list namespaces
- Updated readme to reflect additional cofiguration options