### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report bugs and errors found while using the Operator.
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+### Your environment
+
+<!-- Version of the Operator when the error occurred -->
+Operator Version:
+
+<!-- What version of the Connect server are you running?
+You can get this information from the Integrations section in 1Password
+https://start.1password.com/integrations/active
+-->
+Connect Server Version:
+
+<!-- What version of Kubernetes have you deployed the operator to? -->
+Kubernetes Version:
+
+## What happened?
+<!-- Describe the bug or error -->
+
+## What did you expect to happen?
+<!-- Describe what should have happened -->
+
+## Steps to reproduce
+1. <!-- Describe Steps to reproduce the issue -->
+
+
+## Notes & Logs
+<!-- Paste any logs here that may help with debugging.
+Remember to remove any sensitive information before sharing! -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+# docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
+blank_issues_enabled: true
+contact_links:
+  - name: 1Password Community
+    url: https://1password.community/categories/secrets-automation
+    about: Please ask general Secrets Automation questions here.
+  - name: 1Password Security Bug Bounty
+    url: https://bugcrowd.com/agilebits
+    about: Please report security vulnerabilities here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Suggest an idea for the Operator
+title: ''
+labels: feature-request
+assignees: ''
+
+---
+
+### Summary
+<!-- Briefly describe the feature in one or two sentences. You can include more details later. -->
+
+### Use cases
+<!-- Describe the use cases that make this feature useful to others.
+The description should help the reader understand why the feature is necessary.
+The better we understand your use case, the better we can help create an appropriate solution. -->
+
+### Proposed solution
+<!-- If you already have an idea for how the feature should work, use this space to describe it.
+We'll work with you to find a workable approach, and any implementation details are appreciated.
+-->
+
+### Is there a workaround to accomplish this today?
+<!-- If there's a way to accomplish this feature request without changes to the codebase, we'd like to hear it.
+-->
+
+### References & Prior Work
+<!-- If a similar feature was implemented in another project or tool, add a link so we can better understand your request.
+Links to relevant documentation or RFCs are also appreciated. -->
+
+* <!-- Reference 1 -->
+* <!-- Reference 2, etc -->


### PR DESCRIPTION
This PR adds [issue templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository) to the repository.

The aim of this PR is to help us better manage bug reports and feature requests for this repository.