### PR TITLE
Fix the version passed to the image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,9 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+      - name: Get the version from tag
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/v}
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
@@ -51,4 +54,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            operator_version=${{ github.event.ref }}
+            operator_version=${{ steps.get_version.outputs.VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG operator_version=dev
 RUN CGO_ENABLED=0 \
     GO111MODULE=on \
     go build \
-    -ldflags "-X version.Version=$operator_version" \
+    -ldflags "-X \"github.com/1Password/onepassword-operator/version.Version=$operator_version\"" \
     -mod vendor \
     -a -o manager main.go
 


### PR DESCRIPTION
Version `v1.0.1` of the operator has its internal version not set, so it report `0.0.1` as the version.

Contrary to what internet resources say, `${{github.event.ref}}` also contains the `ref/tags/` prefix. That is removed now.

Also, setting the version with plain "-X version.Version" does not seem to work consistently. Adding the full package as a prefix fixes this.