### PR TITLE
Add arm/v7 image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Needed to run on a Raspberry Pi.

Arm/v6 would also be nice, but this does not seem to be supported by the current base image gcr.io/distroless/static:nonroot. So let's go with this for now.

:heavy_check_mark: Tested on a Raspberry Pi 3.