### PR TITLE
Add support custom namespace for connect deployment

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -85,6 +85,12 @@ func main() {
 
 	namespace := os.Getenv(k8sutil.WatchNamespaceEnvVar)
 
+	deploymentNamespace, err := k8sutil.GetOperatorNamespace()
+	if err != nil {
+		log.Error(err, "Failed to get namespace")
+		os.Exit(1)
+	}
+
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()
 	if err != nil {
@@ -135,7 +141,7 @@ func main() {
 		go func() {
 			connectStarted := false
 			for connectStarted == false {
-				err := op.SetupConnect(mgr.GetClient())
+				err := op.SetupConnect(mgr.GetClient(), deploymentNamespace)
 				// Cache Not Started is an acceptable error. Retry until cache is started.
 				if err != nil && !errors.Is(err, &cache.ErrCacheNotStarted{}) {
 					log.Error(err, "")

--- a/deploy/connect/deployment.yaml
+++ b/deploy/connect/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: onepassword-connect
-  namespace: default
 spec:
   selector:
     matchLabels:

--- a/deploy/connect/service.yaml
+++ b/deploy/connect/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: onepassword-connect
-  namespace: default
 spec:
   type: NodePort
   selector:

--- a/pkg/onepassword/connect_setup_test.go
+++ b/pkg/onepassword/connect_setup_test.go
@@ -25,7 +25,7 @@ func TestServiceSetup(t *testing.T) {
 	// Create a fake client to mock API calls.
 	client := fake.NewFakeClientWithScheme(s, objs...)
 
-	err := setupService(client, "../../deploy/connect/service.yaml")
+	err := setupService(client, "../../deploy/connect/service.yaml", defaultNamespacedName.Namespace)
 
 	if err != nil {
 		t.Errorf("Error Setting Up Connect: %v", err)
@@ -50,7 +50,7 @@ func TestDeploymentSetup(t *testing.T) {
 	// Create a fake client to mock API calls.
 	client := fake.NewFakeClientWithScheme(s, objs...)
 
-	err := setupDeployment(client, "../../deploy/connect/deployment.yaml")
+	err := setupDeployment(client, "../../deploy/connect/deployment.yaml", defaultNamespacedName.Namespace)
 
 	if err != nil {
 		t.Errorf("Error Setting Up Connect: %v", err)


### PR DESCRIPTION
Now when the operator is deployed with the `MANAGE_CONNECT` env var set to true, the connect instance is deployed in the same namespace as the operator.