### PR TITLE
Handling key names

### DIFF
--- a/pkg/controller/onepassworditem/onepassworditem_test.go
+++ b/pkg/controller/onepassworditem/onepassworditem_test.go
@@ -232,7 +232,7 @@ var tests = []testReconcileItem{
 		expectedError:  nil,
 		expectedResultSecret: &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-secret-it3m",
+				Name:      "my-sECReT-it3m",
 				Namespace: namespace,
 				Annotations: map[string]string{
 					op.VersionAnnotation: fmt.Sprint(version),
@@ -264,7 +264,7 @@ var tests = []testReconcileItem{
 		expectedError:  nil,
 		expectedResultSecret: &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-secret-it3m",
+				Name:      "my-sECReT-it3m",
 				Namespace: namespace,
 				Annotations: map[string]string{
 					op.VersionAnnotation: fmt.Sprint(version),
@@ -274,7 +274,7 @@ var tests = []testReconcileItem{
 				"password":       []byte(password),
 				"username":       []byte(username),
 				"first-host":     []byte(firstHost),
-				"aws-access-key": []byte(awsKey),
+				"AWS-Access-Key": []byte(awsKey),
 				"ice-cream-type": []byte(iceCream),
 			},
 		},

--- a/pkg/controller/onepassworditem/onepassworditem_test.go
+++ b/pkg/controller/onepassworditem/onepassworditem_test.go
@@ -286,6 +286,47 @@ var tests = []testReconcileItem{
 			"😄 ice-cream type": iceCream,
 		},
 	},
+	{
+		testName: "Secret from 1Password item with `_` and `.`",
+		customResource: &onepasswordv1.OnePasswordItem{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       onePasswordItemKind,
+				APIVersion: onePasswordItemAPIVersion,
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "!.my_sECReT.it3m%-_",
+				Namespace: namespace,
+			},
+			Spec: onepasswordv1.OnePasswordItemSpec{
+				ItemPath: itemPath,
+			},
+		},
+		existingSecret: nil,
+		expectedError:  nil,
+		expectedResultSecret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "my_sECReT.it3m",
+				Namespace: namespace,
+				Annotations: map[string]string{
+					op.VersionAnnotation: fmt.Sprint(version),
+				},
+			},
+			Data: map[string][]byte{
+				"password":       []byte(password),
+				"username":       []byte(username),
+				"first-host":     []byte(firstHost),
+				"AWS-Access-Key": []byte(awsKey),
+				"ice_cream.type": []byte(iceCream),
+			},
+		},
+		opItem: map[string]string{
+			userKey:               username,
+			passKey:               password,
+			"first host":          firstHost,
+			"AWS Access Key":      awsKey,
+			"😄 -_ice_cream.type.": iceCream,
+		},
+	},
 }
 
 func TestReconcileOnePasswordItem(t *testing.T) {

--- a/pkg/controller/onepassworditem/onepassworditem_test.go
+++ b/pkg/controller/onepassworditem/onepassworditem_test.go
@@ -232,7 +232,7 @@ var tests = []testReconcileItem{
 		expectedError:  nil,
 		expectedResultSecret: &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-sECReT-it3m",
+				Name:      "my-secret-it3m",
 				Namespace: namespace,
 				Annotations: map[string]string{
 					op.VersionAnnotation: fmt.Sprint(version),
@@ -264,7 +264,7 @@ var tests = []testReconcileItem{
 		expectedError:  nil,
 		expectedResultSecret: &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my-sECReT-it3m",
+				Name:      "my-secret-it3m",
 				Namespace: namespace,
 				Annotations: map[string]string{
 					op.VersionAnnotation: fmt.Sprint(version),
@@ -287,7 +287,7 @@ var tests = []testReconcileItem{
 		},
 	},
 	{
-		testName: "Secret from 1Password item with `_` and `.`",
+		testName: "Secret from 1Password item with `-`, `_` and `.`",
 		customResource: &onepasswordv1.OnePasswordItem{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       onePasswordItemKind,
@@ -305,18 +305,18 @@ var tests = []testReconcileItem{
 		expectedError:  nil,
 		expectedResultSecret: &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "my_sECReT.it3m",
+				Name:      "my-secret.it3m",
 				Namespace: namespace,
 				Annotations: map[string]string{
 					op.VersionAnnotation: fmt.Sprint(version),
 				},
 			},
 			Data: map[string][]byte{
-				"password":       []byte(password),
-				"username":       []byte(username),
-				"first-host":     []byte(firstHost),
-				"AWS-Access-Key": []byte(awsKey),
-				"ice_cream.type": []byte(iceCream),
+				"password":          []byte(password),
+				"username":          []byte(username),
+				"first-host":        []byte(firstHost),
+				"AWS-Access-Key":    []byte(awsKey),
+				"-_ice_cream.type.": []byte(iceCream),
 			},
 		},
 		opItem: map[string]string{

--- a/pkg/kubernetessecrets/kubernetes_secrets_builder.go
+++ b/pkg/kubernetessecrets/kubernetes_secrets_builder.go
@@ -97,11 +97,10 @@ func formatSecretName(value string) string {
 	return createValidSecretName(value)
 }
 
-var invalidDNS1123Chars = regexp.MustCompile("[^a-z0-9-]+")
+var invalidDNS1123Chars = regexp.MustCompile("[^a-zA-Z0-9-]+")
 
 func createValidSecretName(value string) string {
-	result := strings.ToLower(value)
-	result = invalidDNS1123Chars.ReplaceAllString(result, "-")
+	result := invalidDNS1123Chars.ReplaceAllString(value, "-")
 
 	if len(result) > kubeValidate.DNS1123SubdomainMaxLength {
 		result = result[0:kubeValidate.DNS1123SubdomainMaxLength]

--- a/pkg/kubernetessecrets/kubernetes_secrets_builder.go
+++ b/pkg/kubernetessecrets/kubernetes_secrets_builder.go
@@ -129,5 +129,10 @@ var invalidStartEndChars = regexp.MustCompile("(^[^a-zA-Z0-9-._]+|[^a-zA-Z0-9-._
 func createValidSecretDataName(value string) string {
 	result := invalidStartEndChars.ReplaceAllString(value, "")
 	result = invalidDataChars.ReplaceAllString(result, "-")
+
+	if len(result) > kubeValidate.DNS1123SubdomainMaxLength {
+		result = result[0:kubeValidate.DNS1123SubdomainMaxLength]
+	}
+
 	return result
 }

--- a/pkg/kubernetessecrets/kubernetes_secrets_builder.go
+++ b/pkg/kubernetessecrets/kubernetes_secrets_builder.go
@@ -97,7 +97,7 @@ func formatSecretName(value string) string {
 	return createValidSecretName(value)
 }
 
-var invalidDNS1123Chars = regexp.MustCompile("[^a-zA-Z0-9-]+")
+var invalidDNS1123Chars = regexp.MustCompile("[^a-zA-Z0-9-_.]+")
 
 func createValidSecretName(value string) string {
 	result := invalidDNS1123Chars.ReplaceAllString(value, "-")
@@ -107,5 +107,5 @@ func createValidSecretName(value string) string {
 	}
 
 	// first and last character MUST be alphanumeric
-	return strings.Trim(result, "-")
+	return strings.Trim(result, "-._")
 }

--- a/pkg/kubernetessecrets/kubernetes_secrets_builder_test.go
+++ b/pkg/kubernetessecrets/kubernetes_secrets_builder_test.go
@@ -102,7 +102,7 @@ func TestBuildKubernetesSecretFromOnePasswordItem(t *testing.T) {
 	item.Fields = generateFields(5)
 
 	kubeSecret := BuildKubernetesSecretFromOnePasswordItem(name, namespace, annotations, item)
-	if kubeSecret.Name != strings.ToLower(name) {
+	if kubeSecret.Name != name {
 		t.Errorf("Expected name value: %v but got: %v", name, kubeSecret.Name)
 	}
 	if kubeSecret.Namespace != namespace {
@@ -116,7 +116,7 @@ func TestBuildKubernetesSecretFromOnePasswordItem(t *testing.T) {
 
 func TestBuildKubernetesSecretFixesInvalidLabels(t *testing.T) {
 	name := "inV@l1d k8s secret%name"
-	expectedName := "inv-l1d-k8s-secret-name"
+	expectedName := "inV-l1d-k8s-secret-name"
 	namespace := "someNamespace"
 	annotations := map[string]string{
 		"annotationKey": "annotationValue",

--- a/pkg/kubernetessecrets/kubernetes_secrets_builder_test.go
+++ b/pkg/kubernetessecrets/kubernetes_secrets_builder_test.go
@@ -129,7 +129,7 @@ func TestBuildKubernetesSecretFixesInvalidLabels(t *testing.T) {
 			Value: "value1",
 		},
 		{
-			Label: strings.Repeat("x", kubeValidate.LabelValueMaxLength+1),
+			Label: strings.Repeat("x", kubeValidate.DNS1123SubdomainMaxLength+1),
 			Value: "name exceeds max length",
 		},
 	}


### PR DESCRIPTION
Add support for capital letters, `.` and `_` in Kubernetes secret key names.

Resolves: #65 