### PR TITLE
More logging if 1password item cant be read and continue processing other items

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -178,7 +178,10 @@ func main() {
 				ticker.Stop()
 				return
 			case <-ticker.C:
-				updatedSecretsPoller.UpdateKubernetesSecretsTask()
+				err := updatedSecretsPoller.UpdateKubernetesSecretsTask()
+				if err != nil {
+					log.Error(err, "error running update kubernetes secret task")
+				}
 			}
 		}
 	}()

--- a/pkg/onepassword/secret_update_handler.go
+++ b/pkg/onepassword/secret_update_handler.go
@@ -118,7 +118,8 @@ func (h *SecretUpdateHandler) updateKubernetesSecrets() (map[string]map[string]*
 
 		item, err := GetOnePasswordItemByPath(h.opConnectClient, secret.Annotations[ItemPathAnnotation])
 		if err != nil {
-			return nil, fmt.Errorf("Failed to retrieve item: %v", err)
+			log.Error(err, "failed to retrieve 1Password item at path \"%s\" for secret \"%s\"", secret.Annotations[ItemPathAnnotation], secret.Name)
+			continue
 		}
 
 		itemVersion := fmt.Sprint(item.Version)


### PR DESCRIPTION
Hello,

We had this issue where we could find out what the problem we had because the of lack of logging.

The problem was due to some annotations in the secrets that we referring to a 1pass item what we didn't have access to (403 forbidden). After adding more logging, we immediately found out that 403 forbidden.

This change will log more output to help the users to debug the problems + if the item fetch fails, it will proceed with the next item.