### PR TITLE
feat: Allow configuration of the Kubernetes Secret type to be created

### DIFF
--- a/deploy/crds/onepassword.com_onepassworditems_crd.yaml
+++ b/deploy/crds/onepassword.com_onepassworditems_crd.yaml
@@ -39,4 +39,7 @@ spec:
           status:
             description: OnePasswordItemStatus defines the observed state of OnePasswordItem
             type: object
+          type:
+            description: 'Kubernetes secret type. More info: https://kubernetes.io/docs/concepts/configuration/secret/#secret-types'
+            type: string
         type: object

--- a/pkg/apis/onepassword/v1/onepasswordsecret_types.go
+++ b/pkg/apis/onepassword/v1/onepasswordsecret_types.go
@@ -26,6 +26,7 @@ type OnePasswordItemStatus struct {
 type OnePasswordItem struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Type              string `json:"type,omitempty"`
 
 	Spec   OnePasswordItemSpec   `json:"spec,omitempty"`
 	Status OnePasswordItemStatus `json:"status,omitempty"`

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -192,6 +192,8 @@ func (r *ReconcileDeployment) HandleApplyingDeployment(namespace string, annotat
 
 	secretName := annotations[op.NameAnnotation]
 	secretLabels := map[string]string(nil)
+	secretType := ""
+
 	if len(secretName) == 0 {
 		reqLog.Info("No 'item-name' annotation set. 'item-path' and 'item-name' must be set as annotations to add new secret.")
 		return nil
@@ -202,5 +204,5 @@ func (r *ReconcileDeployment) HandleApplyingDeployment(namespace string, annotat
 		return fmt.Errorf("Failed to retrieve item: %v", err)
 	}
 
-	return kubeSecrets.CreateKubernetesSecretFromItem(r.kubeClient, secretName, namespace, item, annotations[op.RestartDeploymentsAnnotation], secretLabels, annotations)
+	return kubeSecrets.CreateKubernetesSecretFromItem(r.kubeClient, secretName, namespace, item, annotations[op.RestartDeploymentsAnnotation], secretLabels, secretType, annotations)
 }

--- a/pkg/controller/onepassworditem/onepassworditem_controller.go
+++ b/pkg/controller/onepassworditem/onepassworditem_controller.go
@@ -3,6 +3,7 @@ package onepassworditem
 import (
 	"context"
 	"fmt"
+
 	onepasswordv1 "github.com/1Password/onepassword-operator/pkg/apis/onepassword/v1"
 	kubeSecrets "github.com/1Password/onepassword-operator/pkg/kubernetessecrets"
 	"github.com/1Password/onepassword-operator/pkg/onepassword"
@@ -145,6 +146,7 @@ func (r *ReconcileOnePasswordItem) HandleOnePasswordItem(resource *onepasswordv1
 	secretName := resource.GetName()
 	labels := resource.Labels
 	annotations := resource.Annotations
+	secretType := resource.Type
 	autoRestart := annotations[op.RestartDeploymentsAnnotation]
 
 	item, err := onepassword.GetOnePasswordItemByPath(r.opConnectClient, resource.Spec.ItemPath)
@@ -152,5 +154,5 @@ func (r *ReconcileOnePasswordItem) HandleOnePasswordItem(resource *onepasswordv1
 		return fmt.Errorf("Failed to retrieve item: %v", err)
 	}
 
-	return kubeSecrets.CreateKubernetesSecretFromItem(r.kubeClient, secretName, resource.Namespace, item, autoRestart, labels, annotations)
+	return kubeSecrets.CreateKubernetesSecretFromItem(r.kubeClient, secretName, resource.Namespace, item, autoRestart, labels, secretType, annotations)
 }

--- a/pkg/kubernetessecrets/kubernetes_secrets_builder_test.go
+++ b/pkg/kubernetessecrets/kubernetes_secrets_builder_test.go
@@ -35,7 +35,9 @@ func TestCreateKubernetesSecretFromOnePasswordItem(t *testing.T) {
 	secretAnnotations := map[string]string{
 		"testAnnotation": "exists",
 	}
-	err := CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &item, restartDeploymentAnnotation, secretLabels, secretAnnotations)
+	secretType := ""
+
+	err := CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &item, restartDeploymentAnnotation, secretLabels, secretType, secretAnnotations)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -66,7 +68,10 @@ func TestUpdateKubernetesSecretFromOnePasswordItem(t *testing.T) {
 	kubeClient := fake.NewFakeClient()
 	secretLabels := map[string]string{}
 	secretAnnotations := map[string]string{}
-	err := CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &item, restartDeploymentAnnotation, secretLabels, secretAnnotations)
+	secretType := ""
+
+	err := CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &item, restartDeploymentAnnotation, secretLabels, secretType, secretAnnotations)
+
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -77,7 +82,7 @@ func TestUpdateKubernetesSecretFromOnePasswordItem(t *testing.T) {
 	newItem.Version = 456
 	newItem.Vault.ID = "hfnjvi6aymbsnfc2xeeoheizda"
 	newItem.ID = "h46bb3jddvay7nxopfhvlwg35q"
-	err = CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &newItem, restartDeploymentAnnotation, secretLabels, secretAnnotations)
+	err = CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &newItem, restartDeploymentAnnotation, secretLabels, secretType, secretAnnotations)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -111,8 +116,9 @@ func TestBuildKubernetesSecretFromOnePasswordItem(t *testing.T) {
 	item := onepassword.Item{}
 	item.Fields = generateFields(5)
 	labels := map[string]string{}
+	secretType := ""
 
-	kubeSecret := BuildKubernetesSecretFromOnePasswordItem(name, namespace, annotations, labels, item)
+	kubeSecret := BuildKubernetesSecretFromOnePasswordItem(name, namespace, annotations, labels, secretType, item)
 	if kubeSecret.Name != strings.ToLower(name) {
 		t.Errorf("Expected name value: %v but got: %v", name, kubeSecret.Name)
 	}
@@ -134,6 +140,7 @@ func TestBuildKubernetesSecretFixesInvalidLabels(t *testing.T) {
 	}
 	labels := map[string]string{}
 	item := onepassword.Item{}
+	secretType := ""
 
 	item.Fields = []*onepassword.ItemField{
 		{
@@ -146,7 +153,7 @@ func TestBuildKubernetesSecretFixesInvalidLabels(t *testing.T) {
 		},
 	}
 
-	kubeSecret := BuildKubernetesSecretFromOnePasswordItem(name, namespace, annotations, labels,  item)
+	kubeSecret := BuildKubernetesSecretFromOnePasswordItem(name, namespace, annotations, labels, secretType, item)
 
 	// Assert Secret's meta.name was fixed
 	if kubeSecret.Name != expectedName {
@@ -161,6 +168,39 @@ func TestBuildKubernetesSecretFixesInvalidLabels(t *testing.T) {
 		if !validLabel(key) {
 			t.Errorf("Expected valid kubernetes label, got %s", key)
 		}
+	}
+}
+
+func TestCreateKubernetesTLSSecretFromOnePasswordItem(t *testing.T) {
+	secretName := "tls-test-secret-name"
+	namespace := "test"
+
+	item := onepassword.Item{}
+	item.Fields = generateFields(5)
+	item.Version = 123
+	item.Vault.ID = "hfnjvi6aymbsnfc2xeeoheizda"
+	item.ID = "h46bb3jddvay7nxopfhvlwg35q"
+
+	kubeClient := fake.NewFakeClient()
+	secretLabels := map[string]string{}
+	secretAnnotations := map[string]string{
+		"testAnnotation": "exists",
+	}
+	secretType := "kubernetes.io/tls"
+
+	err := CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &item, restartDeploymentAnnotation, secretLabels, secretType, secretAnnotations)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	createdSecret := &corev1.Secret{}
+	err = kubeClient.Get(context.Background(), types.NamespacedName{Name: secretName, Namespace: namespace}, createdSecret)
+
+	if err != nil {
+		t.Errorf("Secret was not created: %v", err)
+	}
+
+	if createdSecret.Type != corev1.SecretTypeTLS {
+		t.Errorf("Expected secretType to be of tyype corev1.SecretTypeTLS, got %s", string(createdSecret.Type))
 	}
 }
 

--- a/pkg/kubernetessecrets/kubernetes_secrets_types.go
+++ b/pkg/kubernetessecrets/kubernetes_secrets_types.go
@@ -1,0 +1,17 @@
+package kubernetessecrets
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// Default to Opaque as this is Kubernetes' default
+var KubernetesSecretTypes = map[string]corev1.SecretType{
+	"Opaque":                              corev1.SecretTypeOpaque,
+	"kubernetes.io/basic-auth":            corev1.SecretTypeBasicAuth,
+	"kubernetes.io/service-account-token": corev1.SecretTypeServiceAccountToken,
+	"kubernetes.io/dockercfg":             corev1.SecretTypeDockercfg,
+	"kubernetes.io/dockerconfigjson":      corev1.SecretTypeDockerConfigJson,
+	"kubernetes.io/ssh-auth":              corev1.SecretTypeSSHAuth,
+	"kubernetes.io/tls":                   corev1.SecretTypeTLS,
+	"bootstrap.kubernetes.io/token":       corev1.SecretTypeBootstrapToken,
+}

--- a/pkg/onepassword/secret_update_handler.go
+++ b/pkg/onepassword/secret_update_handler.go
@@ -131,7 +131,7 @@ func (h *SecretUpdateHandler) updateKubernetesSecrets() (map[string]map[string]*
 			}
 			log.Info(fmt.Sprintf("Updating kubernetes secret '%v'", secret.GetName()))
 			secret.Annotations[VersionAnnotation] = itemVersion
-			updatedSecret := kubeSecrets.BuildKubernetesSecretFromOnePasswordItem(secret.Name, secret.Namespace, secret.Annotations, secret.Labels, *item)
+			updatedSecret := kubeSecrets.BuildKubernetesSecretFromOnePasswordItem(secret.Name, secret.Namespace, secret.Annotations, secret.Labels, string(secret.Type), *item)
 			h.client.Update(context.Background(), updatedSecret)
 			if updatedSecrets[secret.Namespace] == nil {
 				updatedSecrets[secret.Namespace] = make(map[string]*corev1.Secret)


### PR DESCRIPTION
We need to create a TLS secret to be used with Ingress.

This PR allows the user to select which type of Kubernetes secret to be created by the operator.

For example, if you want to create a `kubernetes.io/tls` certificate you will have something like this:

```yaml
apiVersion: onepassword.com/v1
kind: OnePasswordItem
type: kubernetes.io/tls
metadata:
 name: tls-test
spec:
  itemPath: "vaults/VAULT/items/ITEM"
```

And it will create something like this:

```yaml
apiVersion: v1
data:
  tls.crt: REDACTED
  tls.key: REDACTED
kind: Secret
metadata:
  annotations:
    operator.1password.io/item-path: vaults/VAULT/items/ITEM
    operator.1password.io/item-version: "1"
  creationTimestamp: "2021-11-18T00:09:16Z"
  name: tls-test
  namespace: default
  resourceVersion: "641157"
  uid: a972ad1c-74e9-4ee5-b8ea-0807fa0e4de6
type: kubernetes.io/tls
```

I had to create a custom template for this type of secret to work, so potentially it will be needed for the other type of Kubernetes secrets.

Below is a screenshot of the template for my use case:

![Screen Shot 2021-11-17 at 21 21 25](https://user-images.githubusercontent.com/941928/142308019-71986d76-fff0-4004-ad13-eaa54f6c8ab2.png)

Fixes #38 