### PR TITLE
Verify secrets and EnvFrom in addition to Env

### DIFF
--- a/pkg/onepassword/containers.go
+++ b/pkg/onepassword/containers.go
@@ -7,7 +7,10 @@ import (
 func AreContainersUsingSecrets(containers []corev1.Container, secrets map[string]*corev1.Secret) bool {
 	for i := 0; i < len(containers); i++ {
 		envVariables := containers[i].Env
+		envVariableNames := map[string]struct{}{}
+
 		for j := 0; j < len(envVariables); j++ {
+			envVariableNames[envVariables[j].Name] = struct{}{}
 			if envVariables[j].ValueFrom != nil && envVariables[j].ValueFrom.SecretKeyRef != nil {
 				_, ok := secrets[envVariables[j].ValueFrom.SecretKeyRef.Name]
 				if ok {
@@ -18,6 +21,10 @@ func AreContainersUsingSecrets(containers []corev1.Container, secrets map[string
 		envFromVariables := containers[i].EnvFrom
 		for j := 0; j < len(envFromVariables); j++ {
 			if envFromVariables[j].SecretRef != nil {
+				// Skip env variables that will be overwritten by Env
+				if _, ok := envVariableNames[envFromVariables[i].SecretRef.Name]; ok {
+					continue;
+				}
 				_, ok := secrets[envFromVariables[j].SecretRef.Name]
 				if ok {
 					return true
@@ -31,7 +38,10 @@ func AreContainersUsingSecrets(containers []corev1.Container, secrets map[string
 func AppendUpdatedContainerSecrets(containers []corev1.Container, secrets map[string]*corev1.Secret, updatedDeploymentSecrets map[string]*corev1.Secret) map[string]*corev1.Secret {
 	for i := 0; i < len(containers); i++ {
 		envVariables := containers[i].Env
+		envVariableNames := map[string]struct{}{}
+
 		for j := 0; j < len(envVariables); j++ {
+			envVariableNames[envVariables[j].Name] = struct{}{}
 			if envVariables[j].ValueFrom != nil && envVariables[j].ValueFrom.SecretKeyRef != nil {
 				secret, ok := secrets[envVariables[j].ValueFrom.SecretKeyRef.Name]
 				if ok {
@@ -42,6 +52,10 @@ func AppendUpdatedContainerSecrets(containers []corev1.Container, secrets map[st
 		envFromVariables := containers[i].EnvFrom
 		for j := 0; j < len(envFromVariables); j++ {
 			if envFromVariables[j].SecretRef != nil {
+				// Skip env variables that will be overwritten by Env
+				if _, ok := envVariableNames[envFromVariables[i].SecretRef.Name]; ok {
+					continue;
+				}
 				secret, ok := secrets[envFromVariables[j].SecretRef.LocalObjectReference.Name]
 				if ok {
 					updatedDeploymentSecrets[secret.Name] = secret

--- a/pkg/onepassword/containers.go
+++ b/pkg/onepassword/containers.go
@@ -1,6 +1,8 @@
 package onepassword
 
-import corev1 "k8s.io/api/core/v1"
+import (
+	corev1 "k8s.io/api/core/v1"
+)
 
 func AreContainersUsingSecrets(containers []corev1.Container, secrets map[string]*corev1.Secret) bool {
 	for i := 0; i < len(containers); i++ {
@@ -8,6 +10,15 @@ func AreContainersUsingSecrets(containers []corev1.Container, secrets map[string
 		for j := 0; j < len(envVariables); j++ {
 			if envVariables[j].ValueFrom != nil && envVariables[j].ValueFrom.SecretKeyRef != nil {
 				_, ok := secrets[envVariables[j].ValueFrom.SecretKeyRef.Name]
+				if ok {
+					return true
+				}
+			}
+		}
+		envFromVariables := containers[i].EnvFrom
+		for j := 0; j < len(envFromVariables); j++ {
+			if envFromVariables[j].SecretRef != nil {
+				_, ok := secrets[envFromVariables[j].SecretRef.Name]
 				if ok {
 					return true
 				}
@@ -23,6 +34,15 @@ func AppendUpdatedContainerSecrets(containers []corev1.Container, secrets map[st
 		for j := 0; j < len(envVariables); j++ {
 			if envVariables[j].ValueFrom != nil && envVariables[j].ValueFrom.SecretKeyRef != nil {
 				secret, ok := secrets[envVariables[j].ValueFrom.SecretKeyRef.Name]
+				if ok {
+					updatedDeploymentSecrets[secret.Name] = secret
+				}
+			}
+		}
+		envFromVariables := containers[i].EnvFrom
+		for j := 0; j < len(envFromVariables); j++ {
+			if envFromVariables[j].SecretRef != nil {
+				secret, ok := secrets[envFromVariables[j].SecretRef.LocalObjectReference.Name]
 				if ok {
 					updatedDeploymentSecrets[secret.Name] = secret
 				}

--- a/pkg/onepassword/containers_test.go
+++ b/pkg/onepassword/containers_test.go
@@ -74,14 +74,11 @@ func TestAppendUpdatedContainerSecretsParsesEnvFromEnv(t *testing.T) {
 
 	containers := generateContainersWithSecretRefsFromEnvFrom(containerSecretNames)
 
-	//fmt.Println(containers)
 	updatedDeploymentSecrets := map[string]*corev1.Secret{}
 	updatedDeploymentSecrets = AppendUpdatedContainerSecrets(containers, secretNamesToSearch, updatedDeploymentSecrets)
 
 	secretKeyName := "onepassword-api-key"
 
-	//fmt.Println(updatedDeploymentSecrets)
-	//fmt.Println(secretNamesToSearch)
 	if updatedDeploymentSecrets[secretKeyName] != secretNamesToSearch[secretKeyName] {
 		t.Errorf("Expected that updated Secret from envfrom is found.")
 	}

--- a/pkg/onepassword/containers_test.go
+++ b/pkg/onepassword/containers_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestAreContainersUsingSecrets(t *testing.T) {
+func TestAreContainersUsingSecretsFromEnv(t *testing.T) {
 	secretNamesToSearch := map[string]*corev1.Secret{
 		"onepassword-database-secret": &corev1.Secret{},
 		"onepassword-api-key":         &corev1.Secret{},
@@ -18,7 +19,26 @@ func TestAreContainersUsingSecrets(t *testing.T) {
 		"some_other_key",
 	}
 
-	containers := generateContainers(containerSecretNames)
+	containers := generateContainersWithSecretRefsFromEnv(containerSecretNames)
+
+	if !AreContainersUsingSecrets(containers, secretNamesToSearch) {
+		t.Errorf("Expected that containers were using secrets but they were not detected.")
+	}
+}
+
+func TestAreContainersUsingSecretsFromEnvFrom(t *testing.T) {
+	secretNamesToSearch := map[string]*corev1.Secret{
+		"onepassword-database-secret": {},
+		"onepassword-api-key":         {},
+	}
+
+	containerSecretNames := []string{
+		"onepassword-database-secret",
+		"onepassword-api-key",
+		"some_other_key",
+	}
+
+	containers := generateContainersWithSecretRefsFromEnvFrom(containerSecretNames)
 
 	if !AreContainersUsingSecrets(containers, secretNamesToSearch) {
 		t.Errorf("Expected that containers were using secrets but they were not detected.")
@@ -27,17 +47,42 @@ func TestAreContainersUsingSecrets(t *testing.T) {
 
 func TestAreContainersNotUsingSecrets(t *testing.T) {
 	secretNamesToSearch := map[string]*corev1.Secret{
-		"onepassword-database-secret": &corev1.Secret{},
-		"onepassword-api-key":         &corev1.Secret{},
+		"onepassword-database-secret": {},
+		"onepassword-api-key":         {},
 	}
 
 	containerSecretNames := []string{
 		"some_other_key",
 	}
 
-	containers := generateContainers(containerSecretNames)
+	containers := generateContainersWithSecretRefsFromEnv(containerSecretNames)
 
 	if AreContainersUsingSecrets(containers, secretNamesToSearch) {
 		t.Errorf("Expected that containers were not using secrets but they were detected.")
+	}
+}
+
+func TestAppendUpdatedContainerSecretsParsesEnvFromEnv(t *testing.T) {
+	secretNamesToSearch := map[string]*corev1.Secret{
+		"onepassword-database-secret": {},
+		"onepassword-api-key":         {ObjectMeta: metav1.ObjectMeta{Name: "onepassword-api-key"}},
+	}
+
+	containerSecretNames := []string{
+		"onepassword-api-key",
+	}
+
+	containers := generateContainersWithSecretRefsFromEnvFrom(containerSecretNames)
+
+	//fmt.Println(containers)
+	updatedDeploymentSecrets := map[string]*corev1.Secret{}
+	updatedDeploymentSecrets = AppendUpdatedContainerSecrets(containers, secretNamesToSearch, updatedDeploymentSecrets)
+
+	secretKeyName := "onepassword-api-key"
+
+	//fmt.Println(updatedDeploymentSecrets)
+	//fmt.Println(secretNamesToSearch)
+	if updatedDeploymentSecrets[secretKeyName] != secretNamesToSearch[secretKeyName] {
+		t.Errorf("Expected that updated Secret from envfrom is found.")
 	}
 }

--- a/pkg/onepassword/deployments_test.go
+++ b/pkg/onepassword/deployments_test.go
@@ -39,7 +39,7 @@ func TestIsDeploymentUsingSecretsUsingContainers(t *testing.T) {
 	}
 
 	deployment := &appsv1.Deployment{}
-	deployment.Spec.Template.Spec.Containers = generateContainers(containerSecretNames)
+	deployment.Spec.Template.Spec.Containers = generateContainersWithSecretRefsFromEnv(containerSecretNames)
 	if !IsDeploymentUsingSecrets(deployment, secretNamesToSearch) {
 		t.Errorf("Expected that deployment was using secrets but they were not detected.")
 	}

--- a/pkg/onepassword/object_generators_for_test.go
+++ b/pkg/onepassword/object_generators_for_test.go
@@ -17,8 +17,7 @@ func generateVolumes(names []string) []corev1.Volume {
 	}
 	return volumes
 }
-
-func generateContainers(names []string) []corev1.Container {
+func generateContainersWithSecretRefsFromEnv(names []string) []corev1.Container {
 	containers := []corev1.Container{}
 	for i := 0; i < len(names); i++ {
 		container := corev1.Container{
@@ -34,6 +33,19 @@ func generateContainers(names []string) []corev1.Container {
 						},
 					},
 				},
+			},
+		}
+		containers = append(containers, container)
+	}
+	return containers
+}
+
+func generateContainersWithSecretRefsFromEnvFrom(names []string) []corev1.Container {
+	containers := []corev1.Container{}
+	for i := 0; i < len(names); i++ {
+		container := corev1.Container{
+			EnvFrom: []corev1.EnvFromSource{
+				{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: names[i]}}},
 			},
 		}
 		containers = append(containers, container)


### PR DESCRIPTION
Based off of: https://github.com/1Password/onepassword-operator/pull/74

Resolves: #73 

Adds support for provisioning variables through kubernetes secrets set in the `EnvFrom` field of a container.