### PR TITLE
Fix wrong command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cat 1password-credentials.json | base64 | \
 
 Create a Kubernetes secret from the op-session file:
 ```bash
-kubectl create secret generic op-credentials --from-file=1password-credentials.json=op-session
+kubectl create secret generic op-credentials --from-file=op-session
 ```
 
 Add the following environment variable to the onepassword-connect-operator container in `deploy/operator.yaml`:


### PR DESCRIPTION
This MR fixes an incorrect command in the readme, which can cause issues for anyone trying to set up the operator according to the instructions in the readme.