### PR TITLE
Add owner reference to the created secrets by the operator

### DIFF
--- a/pkg/onepassword/secret_update_handler.go
+++ b/pkg/onepassword/secret_update_handler.go
@@ -140,7 +140,7 @@ func (h *SecretUpdateHandler) updateKubernetesSecrets() (map[string]map[string]*
 			log.Info(fmt.Sprintf("Updating kubernetes secret '%v'", secret.GetName()))
 			secret.Annotations[VersionAnnotation] = itemVersion
 			secret.Annotations[ItemPathAnnotation] = itemPathString
-			updatedSecret := kubeSecrets.BuildKubernetesSecretFromOnePasswordItem(secret.Name, secret.Namespace, secret.Annotations, secret.Labels, string(secret.Type), *item)
+			updatedSecret := kubeSecrets.BuildKubernetesSecretFromOnePasswordItem(secret.Name, secret.Namespace, secret.Annotations, secret.Labels, string(secret.Type), *item, nil)
 			log.Info(fmt.Sprintf("New secret path: %v and version: %v", updatedSecret.Annotations[ItemPathAnnotation], updatedSecret.Annotations[VersionAnnotation]))
 			h.client.Update(context.Background(), updatedSecret)
 			if updatedSecrets[secret.Namespace] == nil {


### PR DESCRIPTION
Fixes #51
Fixes #84
Fixes #96

Hi!

This PR adds support for owner references. The operator now will get the owner reference from the original object (`Deployment` or `OnePasswordItem`) and add it to the operator managed secret.

This way we can track the owners, apply garbage collection, and tools like Argo will know that these resources are created from others and show accordingly so they don't try to prune them.

ArgoCD example:

From this:
![Screenshot_20220405_210510](https://user-images.githubusercontent.com/128204/161830680-18e5325e-feb5-4260-890b-c83d14b6a388.png)

To this:

![Screenshot_20220405_205618](https://user-images.githubusercontent.com/128204/161830531-421c868a-c900-42de-bbcb-4a6c8e8eeb9a.png)
