### PR TITLE
Persist OwnerReferences when item is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Fixes
 
-- A user-friendly description of a fix. {issue-number}
+- OwnerReferences on secrets are now persisted after an item is updated. {#101}
 
 ## Security
 

--- a/pkg/onepassword/secret_update_handler.go
+++ b/pkg/onepassword/secret_update_handler.go
@@ -140,9 +140,9 @@ func (h *SecretUpdateHandler) updateKubernetesSecrets() (map[string]map[string]*
 			log.Info(fmt.Sprintf("Updating kubernetes secret '%v'", secret.GetName()))
 			secret.Annotations[VersionAnnotation] = itemVersion
 			secret.Annotations[ItemPathAnnotation] = itemPathString
-			updatedSecret := kubeSecrets.BuildKubernetesSecretFromOnePasswordItem(secret.Name, secret.Namespace, secret.Annotations, secret.Labels, string(secret.Type), *item, nil)
-			log.Info(fmt.Sprintf("New secret path: %v and version: %v", updatedSecret.Annotations[ItemPathAnnotation], updatedSecret.Annotations[VersionAnnotation]))
-			h.client.Update(context.Background(), updatedSecret)
+			secret.Data = kubeSecrets.BuildKubernetesSecretData(item.Fields, item.Files)
+			log.Info(fmt.Sprintf("New secret path: %v and version: %v", secret.Annotations[ItemPathAnnotation], secret.Annotations[VersionAnnotation]))
+			h.client.Update(context.Background(), &secret)
 			if updatedSecrets[secret.Namespace] == nil {
 				updatedSecrets[secret.Namespace] = make(map[string]*corev1.Secret)
 			}


### PR DESCRIPTION
As reported in #101, the `OwnerReferences` field of a secret got cleared when an item was updated in your vault. This PR uses the existing secret as a base, when updating it, which assures any existing fields like `OwnerReferences` persist.