### PR TITLE
Stop copying annotations from OnePasswordItem and Deployment to Secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ## Fixes
 
-- A user-friendly description of a fix. {issue-number}
+- Annotations from a Deployment or OnePasswordItem are no longer applied to Secrets that are created for it. {#102}
 
 ## Security
 

--- a/pkg/controller/deployment/deployment_controller.go
+++ b/pkg/controller/deployment/deployment_controller.go
@@ -218,5 +218,5 @@ func (r *ReconcileDeployment) HandleApplyingDeployment(deployment *appsv1.Deploy
 		UID:        deployment.GetUID(),
 	}
 
-	return kubeSecrets.CreateKubernetesSecretFromItem(r.kubeClient, secretName, namespace, item, annotations[op.RestartDeploymentsAnnotation], secretLabels, secretType, annotations, ownerRef)
+	return kubeSecrets.CreateKubernetesSecretFromItem(r.kubeClient, secretName, namespace, item, annotations[op.RestartDeploymentsAnnotation], secretLabels, secretType, ownerRef)
 }

--- a/pkg/controller/deployment/deployment_controller_test.go
+++ b/pkg/controller/deployment/deployment_controller_test.go
@@ -281,7 +281,6 @@ var tests = []testReconcileItem{
 				Annotations: map[string]string{
 					op.VersionAnnotation:  fmt.Sprint(version),
 					op.ItemPathAnnotation: itemPath,
-					op.NameAnnotation:     name,
 				},
 			},
 			Data: expectedSecretData,
@@ -294,7 +293,6 @@ var tests = []testReconcileItem{
 				Annotations: map[string]string{
 					op.VersionAnnotation:  fmt.Sprint(version),
 					op.ItemPathAnnotation: itemPath,
-					op.NameAnnotation:     name,
 				},
 				Labels: map[string]string(nil),
 			},
@@ -385,7 +383,7 @@ var tests = []testReconcileItem{
 	},
 }
 
-func TestReconcileDepoyment(t *testing.T) {
+func TestReconcileDeployment(t *testing.T) {
 	for _, testData := range tests {
 		t.Run(testData.testName, func(t *testing.T) {
 

--- a/pkg/controller/onepassworditem/onepassworditem_controller.go
+++ b/pkg/controller/onepassworditem/onepassworditem_controller.go
@@ -147,9 +147,8 @@ func (r *ReconcileOnePasswordItem) removeOnePasswordFinalizerFromOnePasswordItem
 func (r *ReconcileOnePasswordItem) HandleOnePasswordItem(resource *onepasswordv1.OnePasswordItem, request reconcile.Request) error {
 	secretName := resource.GetName()
 	labels := resource.Labels
-	annotations := resource.Annotations
 	secretType := resource.Type
-	autoRestart := annotations[op.RestartDeploymentsAnnotation]
+	autoRestart := resource.Annotations[op.RestartDeploymentsAnnotation]
 
 	item, err := onepassword.GetOnePasswordItemByPath(r.opConnectClient, resource.Spec.ItemPath)
 	if err != nil {
@@ -168,5 +167,5 @@ func (r *ReconcileOnePasswordItem) HandleOnePasswordItem(resource *onepasswordv1
 		UID:        resource.GetUID(),
 	}
 
-	return kubeSecrets.CreateKubernetesSecretFromItem(r.kubeClient, secretName, resource.Namespace, item, autoRestart, labels, secretType, annotations, ownerRef)
+	return kubeSecrets.CreateKubernetesSecretFromItem(r.kubeClient, secretName, resource.Namespace, item, autoRestart, labels, secretType, ownerRef)
 }

--- a/pkg/kubernetessecrets/kubernetes_secrets_builder.go
+++ b/pkg/kubernetessecrets/kubernetes_secrets_builder.go
@@ -35,17 +35,12 @@ var ErrCannotUpdateSecretType = errs.New("Cannot change secret type. Secret type
 
 var log = logf.Log
 
-func CreateKubernetesSecretFromItem(kubeClient kubernetesClient.Client, secretName, namespace string, item *onepassword.Item, autoRestart string, labels map[string]string, secretType string, secretAnnotations map[string]string, ownerRef *metav1.OwnerReference) error {
-
+func CreateKubernetesSecretFromItem(kubeClient kubernetesClient.Client, secretName, namespace string, item *onepassword.Item, autoRestart string, labels map[string]string, secretType string, ownerRef *metav1.OwnerReference) error {
 	itemVersion := fmt.Sprint(item.Version)
-
-	// If secretAnnotations is nil we create an empty map so we can later assign values for the OP Annotations in the map
-	if secretAnnotations == nil {
-		secretAnnotations = map[string]string{}
+	secretAnnotations := map[string]string{
+		VersionAnnotation:  itemVersion,
+		ItemPathAnnotation: fmt.Sprintf("vaults/%v/items/%v", item.Vault.ID, item.ID),
 	}
-
-	secretAnnotations[VersionAnnotation] = itemVersion
-	secretAnnotations[ItemPathAnnotation] = fmt.Sprintf("vaults/%v/items/%v", item.Vault.ID, item.ID)
 
 	if autoRestart != "" {
 		_, err := utils.StringToBool(autoRestart)

--- a/pkg/kubernetessecrets/kubernetes_secrets_builder_test.go
+++ b/pkg/kubernetessecrets/kubernetes_secrets_builder_test.go
@@ -33,12 +33,9 @@ func TestCreateKubernetesSecretFromOnePasswordItem(t *testing.T) {
 
 	kubeClient := fake.NewFakeClient()
 	secretLabels := map[string]string{}
-	secretAnnotations := map[string]string{
-		"testAnnotation": "exists",
-	}
 	secretType := ""
 
-	err := CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &item, restartDeploymentAnnotation, secretLabels, secretType, secretAnnotations, nil)
+	err := CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &item, restartDeploymentAnnotation, secretLabels, secretType, nil)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -50,10 +47,6 @@ func TestCreateKubernetesSecretFromOnePasswordItem(t *testing.T) {
 	}
 	compareFields(item.Fields, createdSecret.Data, t)
 	compareAnnotationsToItem(createdSecret.Annotations, item, t)
-
-	if createdSecret.Annotations["testAnnotation"] != "exists" {
-		t.Errorf("Expected testAnnotation to be merged with existing annotations, but wasn't.")
-	}
 }
 
 func TestKubernetesSecretFromOnePasswordItemOwnerReferences(t *testing.T) {
@@ -68,9 +61,6 @@ func TestKubernetesSecretFromOnePasswordItemOwnerReferences(t *testing.T) {
 
 	kubeClient := fake.NewFakeClient()
 	secretLabels := map[string]string{}
-	secretAnnotations := map[string]string{
-		"testAnnotation": "exists",
-	}
 	secretType := ""
 
 	ownerRef := &metav1.OwnerReference{
@@ -79,7 +69,7 @@ func TestKubernetesSecretFromOnePasswordItemOwnerReferences(t *testing.T) {
 		Name:       "test-deployment",
 		UID:        types.UID("test-uid"),
 	}
-	err := CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &item, restartDeploymentAnnotation, secretLabels, secretType, secretAnnotations, ownerRef)
+	err := CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &item, restartDeploymentAnnotation, secretLabels, secretType, ownerRef)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -116,10 +106,9 @@ func TestUpdateKubernetesSecretFromOnePasswordItem(t *testing.T) {
 
 	kubeClient := fake.NewFakeClient()
 	secretLabels := map[string]string{}
-	secretAnnotations := map[string]string{}
 	secretType := ""
 
-	err := CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &item, restartDeploymentAnnotation, secretLabels, secretType, secretAnnotations, nil)
+	err := CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &item, restartDeploymentAnnotation, secretLabels, secretType, nil)
 
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
@@ -131,7 +120,7 @@ func TestUpdateKubernetesSecretFromOnePasswordItem(t *testing.T) {
 	newItem.Version = 456
 	newItem.Vault.ID = "hfnjvi6aymbsnfc2xeeoheizda"
 	newItem.ID = "h46bb3jddvay7nxopfhvlwg35q"
-	err = CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &newItem, restartDeploymentAnnotation, secretLabels, secretType, secretAnnotations, nil)
+	err = CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &newItem, restartDeploymentAnnotation, secretLabels, secretType, nil)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -232,12 +221,9 @@ func TestCreateKubernetesTLSSecretFromOnePasswordItem(t *testing.T) {
 
 	kubeClient := fake.NewFakeClient()
 	secretLabels := map[string]string{}
-	secretAnnotations := map[string]string{
-		"testAnnotation": "exists",
-	}
 	secretType := "kubernetes.io/tls"
 
-	err := CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &item, restartDeploymentAnnotation, secretLabels, secretType, secretAnnotations, nil)
+	err := CreateKubernetesSecretFromItem(kubeClient, secretName, namespace, &item, restartDeploymentAnnotation, secretLabels, secretType, nil)
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}


### PR DESCRIPTION
There is no reason for random annotations to be carried over from a Deploument or OnePasswordItem to a Secret. This can lead to weird problems like the `kubectl.kubernetes.io/last-applied-configuration` annotation ending up on a Secret as reported in #102.

The only annotation that needs to be copied is `operator.1password.io/auto-restart`, but that already happens explicitly.

Fixes #102.