### PR TITLE
improve vault and item parsing

### DIFF
--- a/pkg/onepassword/items.go
+++ b/pkg/onepassword/items.go
@@ -2,7 +2,7 @@ package onepassword
 
 import (
 	"fmt"
-	"strings"
+	"regexp"
 
 	"github.com/1Password/connect-sdk-go/connect"
 	"github.com/1Password/connect-sdk-go/onepassword"
@@ -42,9 +42,11 @@ func GetOnePasswordItemByPath(opConnectClient connect.Client, path string) (*one
 }
 
 func ParseVaultAndItemFromPath(path string) (string, string, error) {
-	splitPath := strings.Split(path, "/")
-	if len(splitPath) == 4 && splitPath[0] == "vaults" && splitPath[2] == "items" {
-		return splitPath[1], splitPath[3], nil
+	r := regexp.MustCompile("vaults/(.*)/items/(.*)")
+	splitPath := r.FindAllStringSubmatch(path, -1)
+
+	if len(splitPath) == 1 && len(splitPath[0]) == 3 {
+		return splitPath[0][1], splitPath[0][2], nil
 	}
 	return "", "", fmt.Errorf("%q is not an acceptable path for One Password item. Must be of the format: `vaults/{vault_id}/items/{item_id}`", path)
 }

--- a/pkg/onepassword/items_test.go
+++ b/pkg/onepassword/items_test.go
@@ -1,0 +1,57 @@
+package onepassword
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestParseVaultAndItemFromPath(t *testing.T) {
+	cases := []struct {
+		Path  string
+		Vault string
+		Item  string
+		Error error
+	}{
+		{
+			"vaults/foo/items/bar",
+			"foo",
+			"bar",
+			nil,
+		},
+		{
+			"vaults/foo/items/bar/baz",
+			"foo",
+			"bar/baz",
+			nil,
+		},
+		{
+			"vaults/foo/bar/items/baz",
+			"foo/bar",
+			"baz",
+			nil,
+		},
+		{
+			"foo/bar",
+			"",
+			"",
+			fmt.Errorf("\"foo/bar\" is not an acceptable path for One Password item. Must be of the format: `vaults/{vault_id}/items/{item_id}`"),
+		},
+	}
+
+	for _, c := range cases {
+		vault, item, err := ParseVaultAndItemFromPath(c.Path)
+
+		if err != c.Error && err.Error() != c.Error.Error() {
+			t.Errorf("unexpected error %v: %v", err, c.Error)
+		}
+
+		if vault != c.Vault {
+			t.Errorf("couldn't extract vault out of path %s: %s", c.Path, vault)
+		}
+
+		if item != c.Item {
+			t.Errorf("couldn't extract item out of path %s: %s != %s", c.Path, item, c.Item)
+		}
+
+	}
+}


### PR DESCRIPTION
By replacing string.Split in ParseVaultAndItemFromPath with a regexp,
you can use vault and item names containing slashes