### PR TITLE
Avoid returning an error on secret update when secret types 'Opaque' and 'empty string' are treated as different

### DIFF
--- a/pkg/kubernetessecrets/kubernetes_secrets_builder.go
+++ b/pkg/kubernetessecrets/kubernetes_secrets_builder.go
@@ -27,7 +27,6 @@ import (
 const OnepasswordPrefix = "operator.1password.io"
 const NameAnnotation = OnepasswordPrefix + "/item-name"
 const VersionAnnotation = OnepasswordPrefix + "/item-version"
-const restartAnnotation = OnepasswordPrefix + "/last-restarted"
 const ItemPathAnnotation = OnepasswordPrefix + "/item-path"
 const RestartDeploymentsAnnotation = OnepasswordPrefix + "/auto-restart"
 
@@ -63,13 +62,22 @@ func CreateKubernetesSecretFromItem(kubeClient kubernetesClient.Client, secretNa
 		return err
 	}
 
-	currentAnnotations := currentSecret.Annotations
-	currentLabels := currentSecret.Labels
+	// Check if the secret types are being changed on the update.
+	// Avoid Opaque and "" are treated as different on check.
+	wantSecretType := secretType
+	if wantSecretType == "" {
+		wantSecretType = string(corev1.SecretTypeOpaque)
+	}
 	currentSecretType := string(currentSecret.Type)
-	if !reflect.DeepEqual(currentSecretType, secretType) {
+	if currentSecretType == "" {
+		currentSecretType = string(corev1.SecretTypeOpaque)
+	}
+	if currentSecretType != wantSecretType {
 		return ErrCannotUpdateSecretType
 	}
 
+	currentAnnotations := currentSecret.Annotations
+	currentLabels := currentSecret.Labels
 	if !reflect.DeepEqual(currentAnnotations, secretAnnotations) || !reflect.DeepEqual(currentLabels, labels) {
 		log.Info(fmt.Sprintf("Updating Secret %v at namespace '%v'", secret.Name, secret.Namespace))
 		currentSecret.ObjectMeta.Annotations = secretAnnotations


### PR DESCRIPTION
Hi there!

It happens that if we already have a secret with the `Opaque` type and we manage it without setting the secret type feature (type would be `""`), it will start giving errors of this kind:

```
...
"logger":"controller-runtime.controller","msg":"Reconciler error","
controller":"onepassworditem-controller","request":"external-dns/external-dns","error":"Cannot change secret type. Secret type is immutable"
...
```
This is mainly that for Onepassword operator `nil !=  "" != Opaque`, but in reality for the APIserver its the same type. So because 1p operator pre-checks this types instead of letting the apiserver respond if there is an update error, we are not allowing updating secrets on a correct update use case.

This PR makes this use case be treated without error and avoid erroring a correct update.
