### PR TITLE
Migrate operator updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ ifeq ($(USE_IMAGE_DIGESTS), true)
 endif
 
 # Image URL to use all building/pushing image targets
-IMG ?= controller:latest
+IMG ?= 1password/onepassword-operator:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.24.2
 

--- a/Makefile
+++ b/Makefile
@@ -137,8 +137,12 @@ install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~
 uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
 
+.PHONY: set-namespace
+set-namespace:
+	cd config/default && $(KUSTOMIZE) edit set namespace $(shell kubectl config view --minify -o jsonpath={..namespace})
+
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: manifests kustomize set-namespace ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ The 1Password Connect Kubernetes Operator also allows for Kubernetes Secrets to 
 
 The 1Password Connect Kubernetes Operator will continually check for updates from 1Password for any Kubernetes Secret that it has generated. If a Kubernetes Secret is updated, any Deployment using that secret can be automatically restarted.
 
+- [Setup](#setup)
+- [Quickstart for Deploying 1Password Connect to Kubernetes](#quickstart-for-deploying-1password-connect-to-kubernetes)
+- [Kubernetes Operator Deployment](#kubernetes-operator-deployment)
+- [Usage](#usage)
+- [Configuring Automatic Rolling Restarts of Deployments](#configuring-automatic-rolling-restarts-of-deployments)
+- [Development](#development)
+- [Security](#security)
+
 ## Setup
 
 Prerequisites:
@@ -13,10 +21,13 @@ Prerequisites:
 - [1Password Command Line Tool Installed](https://1password.com/downloads/command-line/)
 - [kubectl installed](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [docker installed](https://docs.docker.com/get-docker/)
-- [Generated a 1password-credentials.json file and issued a 1Password Connect API Token for the K8s Operator integration](https://support.1password.com/secrets-automation/)
-- [1Password Connect deployed to Kubernetes](https://support.1password.com/connect-deploy-kubernetes/#step-2-deploy-a-1password-connect-server). **NOTE**: If customization of the 1Password Connect deployment is not required you can skip this prerequisite.
+- [Generated a 1password-credentials.json file and issued a 1Password Connect API Token for the K8s Operator integration](https://developer.1password.com/docs/connect/get-started/#step-1-set-up-a-secrets-automation-workflow)
+- [1Password Connect deployed to Kubernetes](#quickstart-for-deploying-1password-connect-to-kubernetes). **NOTE**: If customization of the 1Password Connect deployment is not required you can skip this prerequisite.
 
-### Quickstart for Deploying 1Password Connect to Kubernetes
+## Quickstart for Deploying 1Password Connect to Kubernetes
+There are options to deploy 1Password Connect:
+- [Deploy with Helm](#deploy-with-helm)
+- [Deploy along with Operator](#deploy-along-with-operator)
 
 #### Deploy with Helm
 The 1Password Connect Helm Chart helps to simplify the deployment of 1Password Connect and the 1Password Connect Kubernetes Operator to Kubernetes.
@@ -38,12 +49,12 @@ Create a Kubernetes secret from the op-session file:
 kubectl create secret generic op-credentials --from-file=op-session
 ```
 
-Add the following environment variable to the onepassword-connect-operator container in `deploy/operator.yaml`:
+Add the following environment variable to the onepassword-connect-operator container in `/config/manager/manager.yaml`:
 ```yaml
 - name: MANAGE_CONNECT
   value: "true"
 ```
-Adding this environment variable will have the operator automatically deploy a default configuration of 1Password Connect to the `default` namespace.
+Adding this environment variable will have the operator automatically deploy a default configuration of 1Password Connect to the current namespace.
 
 ### Kubernetes Operator Deployment
 
@@ -60,6 +71,11 @@ If you do not have a token for the operator, you can generate a token and save i
 kubectl create secret generic onepassword-token --from-literal=token=$(op create connect token <server> op-k8s-operator --vault <vault>)
 ```
 
+**Build Operator docker image**
+```
+make docker-build
+```
+
 **Deploying the Operator**
 
 An sample Deployment yaml can be found at `/config/manager/manager.yaml`.
@@ -69,13 +85,18 @@ To further configure the 1Password Kubernetes Operator the Following Environment
 - **OP_CONNECT_HOST** (required): Specifies the host name within Kubernetes in which to access the 1Password Connect.
 - **WATCH_NAMESPACE:** (default: watch all namespaces): Comma separated list of what Namespaces to watch for changes.
 - **POLLING_INTERVAL** (default: 600): The number of seconds the 1Password Kubernetes Operator will wait before checking for updates from 1Password Connect.
-- **MANAGE_CONNECT** (default: false): If set to true, on deployment of the operator, a default configuration of the OnePassword Connect Service will be deployed to the `default` namespace.
+- **MANAGE_CONNECT** (default: false): If set to true, on deployment of the operator, a default configuration of the OnePassword Connect Service will be deployed to the current namespace.
 - **AUTO_RESTART** (default: false): If set to true, the operator will restart any deployment using a secret from 1Password Connect. This can be overwritten by namespace, deployment, or individual secret. More details on AUTO_RESTART can be found in the ["Configuring Automatic Rolling Restarts of Deployments"](#configuring-automatic-rolling-restarts-of-deployments) section.
 
 To deploy the operator, simply run the following command:
 
 ```shell
 make deploy
+```
+
+**Undeploy Operator**
+```
+make undeploy
 ```
 
 ## Usage
@@ -88,7 +109,7 @@ kind: OnePasswordItem
 metadata:
   name: <item_name> #this name will also be used for naming the generated kubernetes secret
 spec:
-  itemPath: "vaults/<vault_id_or_title>/items/<item_id_or_title>" 
+  itemPath: "vaults/<vault_id_or_title>/items/<item_id_or_title>"
 ```
 
 Deploy the OnePasswordItem to Kubernetes:
@@ -129,26 +150,29 @@ Note: Deleting the Deployment that you've created will automatically delete the 
 If a 1Password Item that is linked to a Kubernetes Secret is updated within the POLLING_INTERVAL the associated Kubernetes Secret will be updated. However, if you do not want a specific secret to be updated you can add the tag `operator.1password.io:ignore-secret` to the item stored in 1Password. While this tag is in place, any updates made to an item will not trigger an update to the associated secret in Kubernetes.
 
 ---
+
 **NOTE**
 
 If multiple 1Password vaults/items have the same `title` when using a title in the access path, the desired action will be performed on the oldest vault/item.
 
 Titles and field names that include white space and other characters that are not a valid [DNS subdomain name](https://kubernetes.io/docs/concepts/configuration/secret/) will create Kubernetes secrets that have titles and fields in the following format:
+
 - Invalid characters before the first alphanumeric character and after the last alphanumeric character will be removed
 - All whitespaces between words will be replaced by `-`
 - All the letters will be lower-cased.
 
 ---
 
-### Configuring Automatic Rolling Restarts of Deployments
+## Configuring Automatic Rolling Restarts of Deployments
 
 If a 1Password Item that is linked to a Kubernetes Secret is updated, any deployments configured to `auto-restart` AND are using that secret will be given a rolling restart the next time 1Password Connect is polled for updates.
 
 There are many levels of granularity on which to configure auto restarts on deployments: at the operator level, per-namespace, or per-deployment.
 
-**On the operator**: This method allows for managing auto restarts on all deployments within the namespaces watched by operator. Auto restarts can be enabled by setting the environemnt variable  `AUTO_RESTART` to true. If the value is not set, the operator will default this value to false.
+**On the operator**: This method allows for managing auto restarts on all deployments within the namespaces watched by operator. Auto restarts can be enabled by setting the environemnt variable `AUTO_RESTART` to true. If the value is not set, the operator will default this value to false.
 
 **Per Namespace**: This method allows for managing auto restarts on all deployments within a namespace. Auto restarts can by managed by setting the annotation `operator.1password.io/auto-restart` to either `true` or `false` on the desired namespace. An example of this is shown below:
+
 ```yaml
 # enabled auto restarts for all deployments within a namespace unless overwritten within a deployment
 apiVersion: v1
@@ -158,10 +182,12 @@ metadata:
   annotations:
     operator.1password.io/auto-restart: "true"
 ```
+
 If the value is not set, the auto restart settings on the operator will be used. This value can be overwritten by deployment.
 
 **Per Deployment**
 This method allows for managing auto restarts on a given deployment. Auto restarts can by managed by setting the annotation `operator.1password.io/auto-restart` to either `true` or `false` on the desired deployment. An example of this is shown below:
+
 ```yaml
 # enabled auto restarts for the deployment
 apiVersion: v1
@@ -171,10 +197,12 @@ metadata:
   annotations:
     operator.1password.io/auto-restart: "true"
 ```
+
 If the value is not set, the auto restart settings on the namespace will be used.
 
 **Per OnePasswordItem Custom Resource**
 This method allows for managing auto restarts on a given OnePasswordItem custom resource. Auto restarts can by managed by setting the annotation `operator.1password.io/auto_restart` to either `true` or `false` on the desired OnePasswordItem. An example of this is shown below:
+
 ```yaml
 # enabled auto restarts for the OnePasswordItem
 apiVersion: onepassword.com/v1
@@ -184,6 +212,7 @@ metadata:
   annotations:
     operator.1password.io/auto-restart: "true"
 ```
+
 If the value is not set, the auto restart settings on the deployment will be used.
 
 <!--
@@ -199,11 +228,11 @@ kubectl apply -f config/samples/
 ```
 
 2. Build and push your image to the location specified by `IMG`:
-    
+
 ```sh
 make docker-build docker-push IMG=<some-registry>/onepassword-operator:tag
 ```
-    
+
 3. Deploy the controller to the cluster with the image specified by `IMG`:
 
 ```sh
@@ -228,12 +257,14 @@ make undeploy
 ## Development
 
 ### How it works
+
 This project aims to follow the Kubernetes [Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
 
 It uses [Controllers](https://kubernetes.io/docs/concepts/architecture/controller/)
 which provides a reconcile function responsible for synchronizing resources untile the desired state is reached on the cluster
 
 ### Test It Out
+
 1. Install the CRDs into the cluster:
 
 ```sh
@@ -249,6 +280,7 @@ make run
 **NOTE:** You can also run this in one step by running: `make install run`
 
 ### Modifying the API definitions
+
 If you are editing the API definitions, generate the manifests such as CRs or CRDs using:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -29,15 +29,18 @@ Prerequisites:
 If 1Password Connect is already running, you can skip this step.
 
 There are options to deploy 1Password Connect:
+
 - [Deploy with Helm](#deploy-with-helm)
 - [Deploy using the Connect Operator](#deploy-using-the-connect-operator)
 
 #### Deploy with Helm
+
 The 1Password Connect Helm Chart helps to simplify the deployment of 1Password Connect and the 1Password Connect Kubernetes Operator to Kubernetes.
 
 [The 1Password Connect Helm Chart can be found here.](https://github.com/1Password/connect-helm-charts)
 
 #### Deploy using the Connect Operator
+
 This guide will provide a quickstart option for deploying a default configuration of 1Password Connect via starting the deploying the 1Password Connect Operator, however it is recommended that you instead deploy your own manifest file if customization of the 1Password Connect deployment is desired.
 
 Encode the 1password-credentials.json file you generated in the prerequisite steps and save it to a file named op-session:
@@ -48,15 +51,18 @@ cat 1password-credentials.json | base64 | \
 ```
 
 Create a Kubernetes secret from the op-session file:
+
 ```bash
 kubectl create secret generic op-credentials --from-file=op-session
 ```
 
 Add the following environment variable to the onepassword-connect-operator container in `/config/manager/manager.yaml`:
+
 ```yaml
 - name: MANAGE_CONNECT
   value: "true"
 ```
+
 Adding this environment variable will have the operator automatically deploy a default configuration of 1Password Connect to the current namespace.
 
 ### Kubernetes Operator Deployment
@@ -70,13 +76,9 @@ kubectl create secret generic onepassword-token --from-literal=token=<OP_CONNECT
 ```
 
 If you do not have a token for the operator, you can generate a token and save it to kubernetes with the following command:
+
 ```bash
 kubectl create secret generic onepassword-token --from-literal=token=$(op create connect token <server> op-k8s-operator --vault <vault>)
-```
-
-**Build Operator docker image**
-```
-make docker-build
 ```
 
 **Deploying the Operator**
@@ -98,6 +100,7 @@ make deploy
 ```
 
 **Undeploy Operator**
+
 ```
 make undeploy
 ```
@@ -230,13 +233,7 @@ You’ll need a Kubernetes cluster to run against. You can use [KIND](https://si
 kubectl apply -f config/samples/
 ```
 
-2. Build and push your image to the location specified by `IMG`:
-
-```sh
-make docker-build docker-push IMG=<some-registry>/onepassword-operator:tag
-```
-
-3. Deploy the controller to the cluster with the image specified by `IMG`:
+2. Deploy the controller to the cluster with the image specified by `IMG`:
 
 ```sh
 make deploy IMG=<some-registry>/onepassword-operator:tag

--- a/README.md
+++ b/README.md
@@ -25,9 +25,12 @@ Prerequisites:
 - [1Password Connect deployed to Kubernetes](#quickstart-for-deploying-1password-connect-to-kubernetes). **NOTE**: If customization of the 1Password Connect deployment is not required you can skip this prerequisite.
 
 ## Quickstart for Deploying 1Password Connect to Kubernetes
+
+If 1Password Connect is already running, you can skip this step.
+
 There are options to deploy 1Password Connect:
 - [Deploy with Helm](#deploy-with-helm)
-- [Deploy along with Operator](#deploy-along-with-operator)
+- [Deploy using the Connect Operator](#deploy-using-the-connect-operator)
 
 #### Deploy with Helm
 The 1Password Connect Helm Chart helps to simplify the deployment of 1Password Connect and the 1Password Connect Kubernetes Operator to Kubernetes.
@@ -35,7 +38,7 @@ The 1Password Connect Helm Chart helps to simplify the deployment of 1Password C
 [The 1Password Connect Helm Chart can be found here.](https://github.com/1Password/connect-helm-charts)
 
 #### Deploy using the Connect Operator
-If 1Password Connect is already running, you can skip this step. This guide will provide a quickstart option for deploying a default configuration of 1Password Connect via starting the deploying the 1Password Connect Operator, however it is recommended that you instead deploy your own manifest file if customization of the 1Password Connect deployment is desired.
+This guide will provide a quickstart option for deploying a default configuration of 1Password Connect via starting the deploying the 1Password Connect Operator, however it is recommended that you instead deploy your own manifest file if customization of the 1Password Connect deployment is desired.
 
 Encode the 1password-credentials.json file you generated in the prerequisite steps and save it to a file named op-session:
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,6 +1,3 @@
-# Adds namespace to all resources.
-namespace: onepassword-operator-system
-
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,7 +38,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: 1password/onepassword-operator:latest
+        image: controller:latest
         name: manager
         env:
           - name: WATCH_NAMESPACE

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -38,7 +38,7 @@ spec:
         - /manager
         args:
         - --leader-elect
-        image: controller:latest
+        image: 1password/onepassword-operator:latest
         name: manager
         env:
           - name: WATCH_NAMESPACE


### PR DESCRIPTION
This PR includes the updates in README and a couple of more major changes.

1. `make docker-build` creates an image called `controller`, therefore we want to use it in the `config/manager/manager.yaml` manifest. 
I tried to change the image name to some custom in Makefile but it brakes everything. Need further investigation on what needs to be done to change it. I think it's ok to go with the default one for now.

2. There was hardcoded `namespace` in `config/default/kastomization.yaml`, therefore it deployed the operator only there.
I adjusted `make deploy` command to use the current user's kubectl config namespace. So, users can control where they want to deploy the operator.