### PR TITLE
Adjust pipeline based on new actions

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -28,7 +28,7 @@ jobs:
 
             if(!releaseBranchName) { return false }
 
-            const {data: prs} = await github.pulls.list({
+            const {data: prs} = await github.rest.pulls.list({
                 ...context.repo,
                 state: 'open',
                 head: `1Password:${releaseBranchName}`,


### PR DESCRIPTION
With #136 we've updated the actions to the latest version.

However, by accident, it slipped that some syntax was changed. Specifically, the [breaking changes in V5](https://github.com/actions/github-script#breaking-changes-in-v5) of `actions/github-script`:
> For example, `github.issues.createComment` in V4 becomes `github.rest.issues.createComment` in V5

This PR addressed this breaking change, making the syntax valid again.