### PR TITLE
generate random version each time calling mock onepassword item

### DIFF
--- a/controllers/onepassworditem_controller_test.go
+++ b/controllers/onepassworditem_controller_test.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"context"
+	"math/rand"
+	"time"
 
 	"github.com/1Password/connect-sdk-go/onepassword"
 	"github.com/1Password/onepassword-operator/pkg/mocks"
@@ -24,6 +26,11 @@ const (
 	iceCream  = "freezing blue 20%"
 )
 
+func randomInt() int {
+	rand.Seed(time.Now().UnixNano())
+	return rand.Intn(1000)
+}
+
 var _ = Describe("OnePasswordItem controller", func() {
 	BeforeEach(func() {
 		// failed test runs that don't clean up leave resources behind.
@@ -38,7 +45,7 @@ var _ = Describe("OnePasswordItem controller", func() {
 			for k, v := range item1.Data {
 				item.Fields = append(item.Fields, &onepassword.ItemField{Label: k, Value: v})
 			}
-			item.Version = item1.Version
+			item.Version = randomInt()
 			item.Vault.ID = vaultUUID
 			item.ID = uuid
 			return &item, nil
@@ -105,7 +112,7 @@ var _ = Describe("OnePasswordItem controller", func() {
 				for k, v := range newData {
 					item.Fields = append(item.Fields, &onepassword.ItemField{Label: k, Value: v})
 				}
-				item.Version = item1.Version + 1
+				item.Version = randomInt()
 				item.Vault.ID = vaultUUID
 				item.ID = uuid
 				return &item, nil
@@ -185,7 +192,7 @@ var _ = Describe("OnePasswordItem controller", func() {
 				for k, v := range testData {
 					item.Fields = append(item.Fields, &onepassword.ItemField{Label: k, Value: v})
 				}
-				item.Version = item1.Version + 1
+				item.Version = randomInt()
 				item.Vault.ID = vaultUUID
 				item.ID = uuid
 				return &item, nil


### PR DESCRIPTION
Sometimes tests fail.
I assume it's because ginkgo runs the tests in parallel in the specs we use the same onepassword item name and version.

I hope to set the random version for each onepassword item might fix it.