### PR TITLE
Feature/migrate operator rename deployment

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -3,7 +3,7 @@
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: onepassword-operator-
+# namePrefix: onepassword-connect-
 
 # Labels to add to all resources and selectors.
 #labels:

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,7 +3,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: onepassword-connect-operator
   namespace: system
 spec:
   template:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: onepassword-connect-operator
   namespace: system
 spec:
   template:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: controller-manager
+  name: onepassword-connect-operator
   namespace: system
   labels:
-    control-plane: controller-manager
+    control-plane: onepassword-connect-operator
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: onepassword-connect-operator
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: controller-manager
+        control-plane: onepassword-connect-operator
     spec:
       securityContext:
         runAsNonRoot: true
@@ -32,6 +32,7 @@ spec:
         args:
         - --leader-elect
         image: 1password/onepassword-operator:latest
+        imagePullPolicy: Never # TODO: remove
         name: manager
         env:
           - name: WATCH_NAMESPACE
@@ -79,5 +80,5 @@ spec:
           requests:
             cpu: 10m
             memory: 64Mi
-      serviceAccountName: controller-manager
+      serviceAccountName: onepassword-connect-operator
       terminationGracePeriodSeconds: 10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -4,18 +4,18 @@ metadata:
   name: onepassword-connect-operator
   namespace: system
   labels:
-    control-plane: onepassword-connect-operator
+    name: onepassword-connect-operator
 spec:
   selector:
     matchLabels:
-      control-plane: onepassword-connect-operator
+      name: onepassword-connect-operator
   replicas: 1
   template:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: manager
       labels:
-        control-plane: onepassword-connect-operator
+        name: onepassword-connect-operator
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -32,7 +32,6 @@ spec:
         args:
         - --leader-elect
         image: 1password/onepassword-operator:latest
-        imagePullPolicy: Never # TODO: remove
         name: manager
         env:
           - name: WATCH_NAMESPACE

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,8 +4,8 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-monitor
+    control-plane: onepassword-connect-operator
+  name: onepassword-connect-operator-metrics-monitor
   namespace: system
 spec:
   endpoints:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: controller-manager
+      control-plane: onepassword-connect-operator

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: onepassword-connect-operator
+    name: onepassword-connect-operator
   name: onepassword-connect-operator-metrics-monitor
   namespace: system
 spec:
@@ -17,4 +17,4 @@ spec:
         insecureSkipVerify: true
   selector:
     matchLabels:
-      control-plane: onepassword-connect-operator
+      name: onepassword-connect-operator

--- a/config/rbac/auth_proxy_role_binding.yaml
+++ b/config/rbac/auth_proxy_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: proxy-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: onepassword-connect-operator
   namespace: system

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
-  name: controller-manager-metrics-service
+    control-plane: onepassword-connect-operator
+  name: onepassword-connect-operator-metrics-service
   namespace: system
 spec:
   ports:
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: onepassword-connect-operator

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: onepassword-connect-operator
+    name: onepassword-connect-operator
   name: onepassword-connect-operator-metrics-service
   namespace: system
 spec:
@@ -12,4 +12,4 @@ spec:
     protocol: TCP
     targetPort: https
   selector:
-    control-plane: onepassword-connect-operator
+    name: onepassword-connect-operator

--- a/config/rbac/leader_election_role_binding.yaml
+++ b/config/rbac/leader_election_role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: leader-election-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: onepassword-connect-operator
   namespace: system

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -8,5 +8,5 @@ roleRef:
   name: manager-role
 subjects:
 - kind: ServiceAccount
-  name: controller-manager
+  name: onepassword-connect-operator
   namespace: system

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: controller-manager
+  name: onepassword-connect-operator
   namespace: system


### PR DESCRIPTION
Change the default `controller-manager` name to be `onepassword-connect-operator` to match the current one in the `main` branch.
Therefore after re-deploy with a new set of `yaml` files we deploy a pod with new code and remove the old one automatically.