### PR TITLE
Code cleanup

### DIFF
--- a/controllers/deployment_controller.go
+++ b/controllers/deployment_controller.go
@@ -110,7 +110,9 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if utils.ContainsString(deployment.ObjectMeta.Finalizers, finalizer) {
 
 		secretName := annotations[op.NameAnnotation]
-		r.cleanupKubernetesSecretForDeployment(secretName, deployment)
+		if err = r.cleanupKubernetesSecretForDeployment(secretName, deployment); err != nil {
+			return ctrl.Result{}, err
+		}
 
 		// Remove the finalizer from the deployment so deletion of deployment can be completed
 		if err := r.removeOnePasswordFinalizerFromDeployment(deployment); err != nil {

--- a/controllers/deployment_controller.go
+++ b/controllers/deployment_controller.go
@@ -95,12 +95,12 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// This is so we can handle cleanup of associated secrets properly
 		if !utils.ContainsString(deployment.ObjectMeta.Finalizers, finalizer) {
 			deployment.ObjectMeta.Finalizers = append(deployment.ObjectMeta.Finalizers, finalizer)
-			if err := r.Update(context.Background(), deployment); err != nil {
+			if err = r.Update(context.Background(), deployment); err != nil {
 				return reconcile.Result{}, err
 			}
 		}
 		// Handles creation or updating secrets for deployment if needed
-		if err := r.handleApplyingDeployment(deployment, deployment.Namespace, annotations, req); err != nil {
+		if err = r.handleApplyingDeployment(deployment, deployment.Namespace, annotations, req); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
@@ -115,7 +115,7 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 
 		// Remove the finalizer from the deployment so deletion of deployment can be completed
-		if err := r.removeOnePasswordFinalizerFromDeployment(deployment); err != nil {
+		if err = r.removeOnePasswordFinalizerFromDeployment(deployment); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
@@ -146,7 +146,7 @@ func (r *DeploymentReconciler) cleanupKubernetesSecretForDeployment(secretName s
 
 	// Only delete the associated kubernetes secret if it is not being used by other deployments
 	if !multipleDeploymentsUsingSecret {
-		if err := r.Delete(context.Background(), kubernetesSecret); err != nil {
+		if err = r.Delete(context.Background(), kubernetesSecret); err != nil {
 			if !errors.IsNotFound(err) {
 				return err
 			}

--- a/controllers/onepassworditem_controller.go
+++ b/controllers/onepassworditem_controller.go
@@ -95,13 +95,13 @@ func (r *OnePasswordItemReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		// This is so we can handle cleanup of associated secrets properly
 		if !utils.ContainsString(onepassworditem.ObjectMeta.Finalizers, finalizer) {
 			onepassworditem.ObjectMeta.Finalizers = append(onepassworditem.ObjectMeta.Finalizers, finalizer)
-			if err := r.Update(context.Background(), onepassworditem); err != nil {
+			if err = r.Update(context.Background(), onepassworditem); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
 
 		// Handles creation or updating secrets for deployment if needed
-		err := r.handleOnePasswordItem(onepassworditem, req)
+		err = r.handleOnePasswordItem(onepassworditem, req)
 		if updateStatusErr := r.updateStatus(onepassworditem, err); updateStatusErr != nil {
 			return ctrl.Result{}, fmt.Errorf("cannot update status: %s", updateStatusErr)
 		}
@@ -116,7 +116,7 @@ func (r *OnePasswordItemReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		}
 
 		// Remove finalizer now that cleanup is complete
-		if err := r.removeFinalizer(onepassworditem); err != nil {
+		if err = r.removeFinalizer(onepassworditem); err != nil {
 			return ctrl.Result{}, err
 		}
 	}

--- a/controllers/onepassworditem_controller.go
+++ b/controllers/onepassworditem_controller.go
@@ -143,7 +143,6 @@ func (r *OnePasswordItemReconciler) cleanupKubernetesSecret(onePasswordItem *one
 	kubernetesSecret.ObjectMeta.Name = onePasswordItem.Name
 	kubernetesSecret.ObjectMeta.Namespace = onePasswordItem.Namespace
 
-	r.Delete(context.Background(), kubernetesSecret)
 	if err := r.Delete(context.Background(), kubernetesSecret); err != nil {
 		if !errors.IsNotFound(err) {
 			return err


### PR DESCRIPTION
This PR adds the following small adjustments to the code that will improve its quality:
- Remove the duplicate code for removing a Kubernetes secret in `controllers/onepassworditem_controller.go`
- Handle the error thrown by `cleanupKubernetesSecretForDeployment` in `controllers/deployment_controller.go`
- Reuse the `err` variable defined in the function and no longer redefine in every time we want to use it.