### PR TITLE
Add runAsNonRoot: true and allowPrivilegeEscalation: false to the specs

### DIFF
--- a/config/connect/deployment.yaml
+++ b/config/connect/deployment.yaml
@@ -12,6 +12,8 @@ spec:
         app: onepassword-connect
         version: "1.0.0"
     spec:
+      securityContext:
+        runAsNonRoot: true
       volumes:
         - name: shared-data
           emptyDir: {}
@@ -32,6 +34,8 @@ spec:
       containers:
         - name: connect-api
           image: 1password/connect-api:latest
+          securityContext:
+            allowPrivilegeEscalation: false
           resources:
             limits:
               memory: "128Mi"
@@ -49,6 +53,8 @@ spec:
               name: shared-data
         - name: connect-sync
           image: 1password/connect-sync:latest
+          securityContext:
+            allowPrivilegeEscalation: false
           resources:
             limits:
               memory: "128Mi"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   template:
     spec:
+      securityContext:
+        runAsNonRoot: true
       containers:
       - name: kube-rbac-proxy
         securityContext:

--- a/config/default/manager_config_patch.yaml
+++ b/config/default/manager_config_patch.yaml
@@ -6,6 +6,8 @@ metadata:
 spec:
   template:
     spec:
+      securityContext:
+        runAsNonRoot: true
       containers:
       - name: manager
         args:


### PR DESCRIPTION
This PR fixes several security vulnerabilities by adding `securityContext` configuration to the specs.

**runAsNonRoot: true** - This will ensure that the container runs as a non-root user,  limiting the damage that could be caused by any potential attacks.

**allowPrivilegeEscalation: false** - This will prevent the container from running any privileged processes and limit the impact of any potential attacks.