### PR TITLE
Regex: corrected regex pattern to match valid annotation

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -58,7 +58,7 @@ const (
 	username2 = "test-user2"
 	password2 = "4zotzqDqXKasLFT2jzTs"
 
-	annotationRegExpString = "^operator.1password.io\\/[a-zA-Z\\.]+"
+	annotationRegExpString = "^operator\.1password\.io\\/[a-zA-Z\\.]+"
 )
 
 // Define utility constants for object names and testing timeouts/durations and intervals.

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ const (
 	restartDeploymentsEnvVariable = "AUTO_RESTART"
 	defaultPollingInterval        = 600
 
-	annotationRegExpString = "^operator.1password.io\\/[a-zA-Z\\.]+"
+	annotationRegExpString = "^operator\.1password\.io\\/[a-zA-Z\\.]+"
 )
 
 // Change below variables to serve metrics on different host or port.


### PR DESCRIPTION
Corrected dot(.) matches by adding escape pattern.

Invalid operator string such as `operator11passwordiio\/some\text`, `operator$1password0io\/some\text` are also getting matched with current pattern.

Added fix so it will matches only desired string such as `operator.1password.io\/some\text`

created playground to test pattern: https://regex101.com/r/r5fUXv/1