### PR TITLE
Upgrade operator go sdk to 1.29.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ export MAIN_BRANCH ?= main
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.5.0
+VERSION ?= 1.6.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
@@ -51,7 +51,7 @@ endif
 # Image URL to use all building/pushing image targets
 IMG ?= 1password/onepassword-operator:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
-ENVTEST_K8S_VERSION = 1.24.2
+ENVTEST_K8S_VERSION = 1.26
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -110,7 +110,7 @@ test: manifests generate fmt vet envtest ## Run tests.
 ##@ Build
 
 .PHONY: build
-build: generate fmt vet ## Build manager binary.
+build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
 .PHONY: run

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -17,7 +17,7 @@ spec:
           capabilities:
             drop:
               - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/version/version.go
+++ b/version/version.go
@@ -2,5 +2,5 @@ package version
 
 var (
 	OperatorVersion    = "1.6.0"
-	OperatorSDKVersion = "1.25.0"
+	OperatorSDKVersion = "1.29.0"
 )


### PR DESCRIPTION
The steps performed to upgrade the Operator SDK for Go from `1.25.0` to `1.29.0` were the following:
- Update dependencies in `Makefile` and  `config/default/manager_auth_proxy_patch.yaml`.

No Go mod dependencies were updated for the following reasons:
- According to the [upgrade to v1.28.0](https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.28.0/), we needed the following version for the following packages, which we already have or are higher:
  ```go
  k8s.io/api v0.26.2 
  k8s.io/apiextensions-apiserver v0.26.2 
  k8s.io/apimachinery v0.26.2 
  k8s.io/client-go v0.26.2 
  k8s.io/kubectl v0.26.2 
  sigs.k8s.io/controller-runtime v0.14.5 
  ```
- Updating these to the latest version (`v0.27.3` as of this writing) seems to break building the operator with the following error:
  ```
  # k8s.io/client-go/applyconfigurations/meta/v1
  vendor/k8s.io/client-go/applyconfigurations/meta/v1/unstructured.go:64:38: cannot use doc (variable of type *"github.com/google/gnostic/openapiv2".Document) as *"github.com/google/gnostic-models/openapiv2".Document value in argument to proto.NewOpenAPIData
  ```

These are based on the steps presented in [upgrading to v1.28.0](https://sdk.operatorframework.io/docs/upgrading-sdk-version/v1.28.0/), since that is the version that has changes relevant to a Go operator (which is our case).