### PR TITLE
Adjusting logging level on various logs

### DIFF
--- a/USAGEGUIDE.md
+++ b/USAGEGUIDE.md
@@ -88,7 +88,7 @@ To further configure the 1Password Kubernetes Operator the following Environment
 - **MANAGE_CONNECT** *(default: false)*: If set to true, on deployment of the operator, a default configuration of the OnePassword Connect Service will be deployed to the current namespace.
 - **AUTO_RESTART** (default: false): If set to true, the operator will restart any deployment using a secret from 1Password Connect. This can be overwritten by namespace, deployment, or individual secret. More details on AUTO_RESTART can be found in the ["Configuring Automatic Rolling Restarts of Deployments"](#configuring-automatic-rolling-restarts-of-deployments) section.
 
-You can also set the logging level by setting `--zap-log-level` as an arg on the containers to either `debug`, `info` or `error`.
+You can also set the logging level by setting `--zap-log-level` as an arg on the containers to either `debug`, `info` or `error`. (Note: the default value is `debug`.)
 
 Example:
 ```

--- a/USAGEGUIDE.md
+++ b/USAGEGUIDE.md
@@ -91,7 +91,7 @@ To further configure the 1Password Kubernetes Operator the following Environment
 You can also set the logging level by setting `--zap-log-level` as an arg on the containers to either `debug`, `info` or `error`. (Note: the default value is `debug`.)
 
 Example:
-```
+```yaml
 .
 .
 .

--- a/USAGEGUIDE.md
+++ b/USAGEGUIDE.md
@@ -88,6 +88,24 @@ To further configure the 1Password Kubernetes Operator the following Environment
 - **MANAGE_CONNECT** *(default: false)*: If set to true, on deployment of the operator, a default configuration of the OnePassword Connect Service will be deployed to the current namespace.
 - **AUTO_RESTART** (default: false): If set to true, the operator will restart any deployment using a secret from 1Password Connect. This can be overwritten by namespace, deployment, or individual secret. More details on AUTO_RESTART can be found in the ["Configuring Automatic Rolling Restarts of Deployments"](#configuring-automatic-rolling-restarts-of-deployments) section.
 
+You can also set the logging level by setting `--zap-log-level` as an arg on the containers to either `debug`, `info` or `error`.
+
+Example:
+```
+.
+.
+.
+containers:
+      - command:
+        - /manager
+        args:
+        - --leader-elect
+        - --zap-log-level=info
+        image: 1password/onepassword-operator:latest
+.
+.
+.
+```
 To deploy the operator, simply run the following command:
 
 ```shell

--- a/config/crd/bases/onepassword.com_onepassworditems.yaml
+++ b/config/crd/bases/onepassword.com_onepassworditems.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: onepassworditems.onepassword.com
 spec:

--- a/controllers/deployment_controller.go
+++ b/controllers/deployment_controller.go
@@ -74,7 +74,7 @@ type DeploymentReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile
 func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := logDeployment.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
-	reqLogger.V(int(logs.DebugLevel)).Info("Reconciling Deployment")
+	reqLogger.V(logs.DebugLevel).Info("Reconciling Deployment")
 
 	deployment := &appsv1.Deployment{}
 	err := r.Get(context.Background(), req.NamespacedName, deployment)
@@ -87,7 +87,7 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	annotations, annotationsFound := op.GetAnnotationsForDeployment(deployment, r.OpAnnotationRegExp)
 	if !annotationsFound {
-		reqLogger.V(int(logs.DebugLevel)).Info("No 1Password Annotations found")
+		reqLogger.V(logs.DebugLevel).Info("No 1Password Annotations found")
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/deployment_controller.go
+++ b/controllers/deployment_controller.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/1Password/connect-sdk-go/connect"
@@ -72,7 +73,7 @@ type DeploymentReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile
 func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := logDeployment.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
-	reqLogger.Info("Reconciling Deployment")
+	reqLogger.V(1).Info("Reconciling Deployment")
 
 	deployment := &appsv1.Deployment{}
 	err := r.Get(context.Background(), req.NamespacedName, deployment)
@@ -85,7 +86,7 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	annotations, annotationsFound := op.GetAnnotationsForDeployment(deployment, r.OpAnnotationRegExp)
 	if !annotationsFound {
-		reqLogger.Info("No 1Password Annotations found")
+		reqLogger.V(1).Info("No 1Password Annotations found")
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/deployment_controller.go
+++ b/controllers/deployment_controller.go
@@ -34,6 +34,7 @@ import (
 	"github.com/1Password/connect-sdk-go/connect"
 
 	kubeSecrets "github.com/1Password/onepassword-operator/pkg/kubernetessecrets"
+	"github.com/1Password/onepassword-operator/pkg/logs"
 	op "github.com/1Password/onepassword-operator/pkg/onepassword"
 	"github.com/1Password/onepassword-operator/pkg/utils"
 
@@ -73,7 +74,7 @@ type DeploymentReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile
 func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := logDeployment.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
-	reqLogger.V(1).Info("Reconciling Deployment")
+	reqLogger.V(int(logs.DebugLevel)).Info("Reconciling Deployment")
 
 	deployment := &appsv1.Deployment{}
 	err := r.Get(context.Background(), req.NamespacedName, deployment)
@@ -86,7 +87,7 @@ func (r *DeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	annotations, annotationsFound := op.GetAnnotationsForDeployment(deployment, r.OpAnnotationRegExp)
 	if !annotationsFound {
-		reqLogger.V(1).Info("No 1Password Annotations found")
+		reqLogger.V(int(logs.DebugLevel)).Info("No 1Password Annotations found")
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/onepassworditem_controller.go
+++ b/controllers/onepassworditem_controller.go
@@ -32,6 +32,7 @@ import (
 
 	onepasswordv1 "github.com/1Password/onepassword-operator/api/v1"
 	kubeSecrets "github.com/1Password/onepassword-operator/pkg/kubernetessecrets"
+	"github.com/1Password/onepassword-operator/pkg/logs"
 	op "github.com/1Password/onepassword-operator/pkg/onepassword"
 	"github.com/1Password/onepassword-operator/pkg/utils"
 
@@ -78,7 +79,7 @@ type OnePasswordItemReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile
 func (r *OnePasswordItemReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := logOnePasswordItem.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
-	reqLogger.V(1).Info("Reconciling OnePasswordItem")
+	reqLogger.V(int(logs.DebugLevel)).Info("Reconciling OnePasswordItem")
 
 	onepassworditem := &onepasswordv1.OnePasswordItem{}
 	err := r.Get(context.Background(), req.NamespacedName, onepassworditem)

--- a/controllers/onepassworditem_controller.go
+++ b/controllers/onepassworditem_controller.go
@@ -78,7 +78,7 @@ type OnePasswordItemReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile
 func (r *OnePasswordItemReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := logOnePasswordItem.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
-	reqLogger.Info("Reconciling OnePasswordItem")
+	reqLogger.V(1).Info("Reconciling OnePasswordItem")
 
 	onepassworditem := &onepasswordv1.OnePasswordItem{}
 	err := r.Get(context.Background(), req.NamespacedName, onepassworditem)

--- a/controllers/onepassworditem_controller.go
+++ b/controllers/onepassworditem_controller.go
@@ -79,7 +79,7 @@ type OnePasswordItemReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile
 func (r *OnePasswordItemReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	reqLogger := logOnePasswordItem.WithValues("Request.Namespace", req.Namespace, "Request.Name", req.Name)
-	reqLogger.V(int(logs.DebugLevel)).Info("Reconciling OnePasswordItem")
+	reqLogger.V(logs.DebugLevel).Info("Reconciling OnePasswordItem")
 
 	onepassworditem := &onepasswordv1.OnePasswordItem{}
 	err := r.Get(context.Background(), req.NamespacedName, onepassworditem)

--- a/main.go
+++ b/main.go
@@ -123,6 +123,15 @@ func main() {
 		os.Exit(1)
 	}
 
+	setupLog.V(1).Info("this should be debug")
+	setupLog.V(0).Info("this should be info")
+	setupLog.V(-1).Info("this should be level 1")
+
+	setupLog.V(-2).Info("this is level 2")
+	setupLog.V(-3).Info("this is level 3 ")
+	setupLog.Info("this should be be here by default")
+	setupLog.Error(nil, "errorrr")
+
 	options := ctrl.Options{
 		Scheme:                 scheme,
 		Namespace:              watchNamespace,

--- a/main.go
+++ b/main.go
@@ -123,15 +123,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.V(1).Info("this should be debug")
-	setupLog.V(0).Info("this should be info")
-	setupLog.V(-1).Info("this should be level 1")
-
-	setupLog.V(-2).Info("this is level 2")
-	setupLog.V(-3).Info("this is level 3 ")
-	setupLog.Info("this should be be here by default")
-	setupLog.Error(nil, "errorrr")
-
 	options := ctrl.Options{
 		Scheme:                 scheme,
 		Namespace:              watchNamespace,

--- a/pkg/logs/log_levels.go
+++ b/pkg/logs/log_levels.go
@@ -3,11 +3,9 @@ package logs
 // A Level is a logging priority. Lower levels are more important.
 // All levels have been multipled by -1 to ensure compatibilty
 // between zapcore and logr
-type Level int
-
 const (
-	ErrorLevel Level = iota - 2
-	WarnLevel
-	InfoLevel
-	DebugLevel
+	ErrorLevel = -2
+	WarnLevel  = -1
+	InfoLevel  = 0
+	DebugLevel = 1
 )

--- a/pkg/logs/log_levels.go
+++ b/pkg/logs/log_levels.go
@@ -1,0 +1,13 @@
+package logs
+
+// A Level is a logging priority. Lower levels are more important.
+// All levels have been multipled by -1 to ensure compatibilty
+// between zapcore and logr
+type Level int
+
+const (
+	ErrorLevel Level = iota - 2
+	WarnLevel
+	InfoLevel
+	DebugLevel
+)

--- a/pkg/onepassword/secret_update_handler.go
+++ b/pkg/onepassword/secret_update_handler.go
@@ -82,7 +82,7 @@ func (h *SecretUpdateHandler) restartDeploymentsWithUpdatedSecrets(updatedSecret
 			}
 		}
 
-		log.Info(fmt.Sprintf("Deployment %q at namespace %q is up to date", deployment.GetName(), deployment.Namespace))
+		log.V(1).Info(fmt.Sprintf("Deployment %q at namespace %q is up to date", deployment.GetName(), deployment.Namespace))
 
 	}
 	return nil
@@ -131,7 +131,7 @@ func (h *SecretUpdateHandler) updateKubernetesSecrets() (map[string]map[string]*
 
 		if currentVersion != itemVersion || secret.Annotations[ItemPathAnnotation] != itemPathString {
 			if isItemLockedForForcedRestarts(item) {
-				log.Info(fmt.Sprintf("Secret '%v' has been updated in 1Password but is set to be ignored. Updates to an ignored secret will not trigger an update to a kubernetes secret or a rolling restart.", secret.GetName()))
+				log.V(1).Info(fmt.Sprintf("Secret '%v' has been updated in 1Password but is set to be ignored. Updates to an ignored secret will not trigger an update to a kubernetes secret or a rolling restart.", secret.GetName()))
 				secret.Annotations[VersionAnnotation] = itemVersion
 				secret.Annotations[ItemPathAnnotation] = itemPathString
 				if err := h.client.Update(context.Background(), &secret); err != nil {
@@ -144,7 +144,7 @@ func (h *SecretUpdateHandler) updateKubernetesSecrets() (map[string]map[string]*
 			secret.Annotations[VersionAnnotation] = itemVersion
 			secret.Annotations[ItemPathAnnotation] = itemPathString
 			secret.Data = kubeSecrets.BuildKubernetesSecretData(item.Fields, item.Files)
-			log.Info(fmt.Sprintf("New secret path: %v and version: %v", secret.Annotations[ItemPathAnnotation], secret.Annotations[VersionAnnotation]))
+			log.V(1).Info(fmt.Sprintf("New secret path: %v and version: %v", secret.Annotations[ItemPathAnnotation], secret.Annotations[VersionAnnotation]))
 			if err := h.client.Update(context.Background(), &secret); err != nil {
 				log.Error(err, "failed to update secret %s to version %d: %s", secret.Name, itemVersion, err)
 				continue

--- a/pkg/onepassword/secret_update_handler.go
+++ b/pkg/onepassword/secret_update_handler.go
@@ -83,7 +83,7 @@ func (h *SecretUpdateHandler) restartDeploymentsWithUpdatedSecrets(updatedSecret
 			}
 		}
 
-		log.V(int(logs.DebugLevel)).Info(fmt.Sprintf("Deployment %q at namespace %q is up to date", deployment.GetName(), deployment.Namespace))
+		log.V(logs.DebugLevel).Info(fmt.Sprintf("Deployment %q at namespace %q is up to date", deployment.GetName(), deployment.Namespace))
 
 	}
 	return nil
@@ -132,7 +132,7 @@ func (h *SecretUpdateHandler) updateKubernetesSecrets() (map[string]map[string]*
 
 		if currentVersion != itemVersion || secret.Annotations[ItemPathAnnotation] != itemPathString {
 			if isItemLockedForForcedRestarts(item) {
-				log.V(int(logs.DebugLevel)).Info(fmt.Sprintf("Secret '%v' has been updated in 1Password but is set to be ignored. Updates to an ignored secret will not trigger an update to a kubernetes secret or a rolling restart.", secret.GetName()))
+				log.V(logs.DebugLevel).Info(fmt.Sprintf("Secret '%v' has been updated in 1Password but is set to be ignored. Updates to an ignored secret will not trigger an update to a kubernetes secret or a rolling restart.", secret.GetName()))
 				secret.Annotations[VersionAnnotation] = itemVersion
 				secret.Annotations[ItemPathAnnotation] = itemPathString
 				if err := h.client.Update(context.Background(), &secret); err != nil {
@@ -145,7 +145,7 @@ func (h *SecretUpdateHandler) updateKubernetesSecrets() (map[string]map[string]*
 			secret.Annotations[VersionAnnotation] = itemVersion
 			secret.Annotations[ItemPathAnnotation] = itemPathString
 			secret.Data = kubeSecrets.BuildKubernetesSecretData(item.Fields, item.Files)
-			log.V(int(logs.DebugLevel)).Info(fmt.Sprintf("New secret path: %v and version: %v", secret.Annotations[ItemPathAnnotation], secret.Annotations[VersionAnnotation]))
+			log.V(logs.DebugLevel).Info(fmt.Sprintf("New secret path: %v and version: %v", secret.Annotations[ItemPathAnnotation], secret.Annotations[VersionAnnotation]))
 			if err := h.client.Update(context.Background(), &secret); err != nil {
 				log.Error(err, "failed to update secret %s to version %d: %s", secret.Name, itemVersion, err)
 				continue

--- a/pkg/onepassword/secret_update_handler.go
+++ b/pkg/onepassword/secret_update_handler.go
@@ -7,6 +7,7 @@ import (
 
 	onepasswordv1 "github.com/1Password/onepassword-operator/api/v1"
 	kubeSecrets "github.com/1Password/onepassword-operator/pkg/kubernetessecrets"
+	"github.com/1Password/onepassword-operator/pkg/logs"
 	"github.com/1Password/onepassword-operator/pkg/utils"
 
 	"github.com/1Password/connect-sdk-go/connect"
@@ -82,7 +83,7 @@ func (h *SecretUpdateHandler) restartDeploymentsWithUpdatedSecrets(updatedSecret
 			}
 		}
 
-		log.V(1).Info(fmt.Sprintf("Deployment %q at namespace %q is up to date", deployment.GetName(), deployment.Namespace))
+		log.V(int(logs.DebugLevel)).Info(fmt.Sprintf("Deployment %q at namespace %q is up to date", deployment.GetName(), deployment.Namespace))
 
 	}
 	return nil
@@ -131,7 +132,7 @@ func (h *SecretUpdateHandler) updateKubernetesSecrets() (map[string]map[string]*
 
 		if currentVersion != itemVersion || secret.Annotations[ItemPathAnnotation] != itemPathString {
 			if isItemLockedForForcedRestarts(item) {
-				log.V(1).Info(fmt.Sprintf("Secret '%v' has been updated in 1Password but is set to be ignored. Updates to an ignored secret will not trigger an update to a kubernetes secret or a rolling restart.", secret.GetName()))
+				log.V(int(logs.DebugLevel)).Info(fmt.Sprintf("Secret '%v' has been updated in 1Password but is set to be ignored. Updates to an ignored secret will not trigger an update to a kubernetes secret or a rolling restart.", secret.GetName()))
 				secret.Annotations[VersionAnnotation] = itemVersion
 				secret.Annotations[ItemPathAnnotation] = itemPathString
 				if err := h.client.Update(context.Background(), &secret); err != nil {
@@ -144,7 +145,7 @@ func (h *SecretUpdateHandler) updateKubernetesSecrets() (map[string]map[string]*
 			secret.Annotations[VersionAnnotation] = itemVersion
 			secret.Annotations[ItemPathAnnotation] = itemPathString
 			secret.Data = kubeSecrets.BuildKubernetesSecretData(item.Fields, item.Files)
-			log.V(1).Info(fmt.Sprintf("New secret path: %v and version: %v", secret.Annotations[ItemPathAnnotation], secret.Annotations[VersionAnnotation]))
+			log.V(int(logs.DebugLevel)).Info(fmt.Sprintf("New secret path: %v and version: %v", secret.Annotations[ItemPathAnnotation], secret.Annotations[VersionAnnotation]))
 			if err := h.client.Update(context.Background(), &secret); err != nil {
 				log.Error(err, "failed to update secret %s to version %d: %s", secret.Name, itemVersion, err)
 				continue

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/1Password/onepassword-operator/pkg/logs"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -54,7 +55,7 @@ func GetOperatorNamespace() (string, error) {
 		return "", err
 	}
 	ns := strings.TrimSpace(string(nsBytes))
-	log.V(1).Info("Found namespace", "Namespace", ns)
+	log.V(int(logs.DebugLevel)).Info("Found namespace", "Namespace", ns)
 	return ns, nil
 }
 

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -55,7 +55,7 @@ func GetOperatorNamespace() (string, error) {
 		return "", err
 	}
 	ns := strings.TrimSpace(string(nsBytes))
-	log.V(int(logs.DebugLevel)).Info("Found namespace", "Namespace", ns)
+	log.V(logs.DebugLevel).Info("Found namespace", "Namespace", ns)
 	return ns, nil
 }
 


### PR DESCRIPTION
Various logs have been updated to only print when log level is set to debug. This is to address the large number of info logs being printed.

Also added instructions on how to update the log level.

Addresses #164