### PR TITLE
Use requests instead of limits for cpu resource

### DIFF
--- a/config/connect/deployment.yaml
+++ b/config/connect/deployment.yaml
@@ -60,7 +60,7 @@ spec:
             limits:
               memory: "128Mi"
             requests:
-              cpu: "0.2m"
+              cpu: "0.2"
           ports:
             - containerPort: 8081
           env:

--- a/config/connect/deployment.yaml
+++ b/config/connect/deployment.yaml
@@ -40,7 +40,7 @@ spec:
             limits:
               memory: "128Mi"
             requests:
-              cpu: "0.2m"
+              cpu: "0.2"
           ports:
             - containerPort: 8080
           env:

--- a/config/connect/deployment.yaml
+++ b/config/connect/deployment.yaml
@@ -39,7 +39,8 @@ spec:
           resources:
             limits:
               memory: "128Mi"
-              cpu: "0.2"
+            requests:
+              cpu: "0.2m"
           ports:
             - containerPort: 8080
           env:
@@ -58,7 +59,8 @@ spec:
           resources:
             limits:
               memory: "128Mi"
-              cpu: "0.2"
+            requests:
+              cpu: "0.2m"
           ports:
             - containerPort: 8081
           env:


### PR DESCRIPTION
Since CPU is a compressible resource it makes sense for us not to limit it. Furthermore, since we want to meet the conditions for our node to be catalogued as burstable by Kubernetes we want to provide a request spec.