### PR TITLE
Generalise auto-restart logic to support workloads other than Deployments

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -65,10 +65,10 @@ var (
 )
 
 const (
-	envPollingIntervalVariable    = "POLLING_INTERVAL"
-	manageConnect                 = "MANAGE_CONNECT"
-	restartDeploymentsEnvVariable = "AUTO_RESTART"
-	defaultPollingInterval        = 600
+	envPollingIntervalVariable  = "POLLING_INTERVAL"
+	manageConnect               = "MANAGE_CONNECT"
+	restartWorkloadsEnvVariable = "AUTO_RESTART"
+	defaultPollingInterval      = 600
 
 	annotationRegExpString = "^operator.1password.io\\/[a-zA-Z\\.]+"
 )
@@ -202,7 +202,7 @@ func main() {
 	}
 
 	// Setup update secrets task
-	updatedSecretsPoller := op.NewManager(mgr.GetClient(), opConnectClient, shouldAutoRestartDeployments())
+	updatedSecretsPoller := op.NewManager(mgr.GetClient(), opConnectClient, shouldAutoRestartWorkloads())
 	done := make(chan bool)
 	ticker := time.NewTicker(getPollingIntervalForUpdatingSecrets())
 	go func() {
@@ -263,15 +263,15 @@ func shouldManageConnect() bool {
 	return false
 }
 
-func shouldAutoRestartDeployments() bool {
-	shouldAutoRestartDeployments, found := os.LookupEnv(restartDeploymentsEnvVariable)
+func shouldAutoRestartWorkloads() bool {
+	value, found := os.LookupEnv(restartWorkloadsEnvVariable)
 	if found {
-		shouldAutoRestartDeploymentsBool, err := strconv.ParseBool(strings.ToLower(shouldAutoRestartDeployments))
+		shouldAutoRestartWorkloadsBool, err := strconv.ParseBool(strings.ToLower(value))
 		if err != nil {
 			setupLog.Error(err, "")
 			os.Exit(1)
 		}
-		return shouldAutoRestartDeploymentsBool
+		return shouldAutoRestartWorkloadsBool
 	}
 	return false
 }

--- a/internal/controller/deployment_controller.go
+++ b/internal/controller/deployment_controller.go
@@ -213,5 +213,5 @@ func (r *DeploymentReconciler) handleApplyingDeployment(deployment *appsv1.Deplo
 		UID:        deployment.GetUID(),
 	}
 
-	return kubeSecrets.CreateKubernetesSecretFromItem(r.Client, secretName, namespace, item, annotations[op.RestartDeploymentsAnnotation], secretLabels, secretType, ownerRef)
+	return kubeSecrets.CreateKubernetesSecretFromItem(r.Client, secretName, namespace, item, annotations[op.AutoRestartWorkloadAnnotation], secretLabels, secretType, ownerRef)
 }

--- a/internal/controller/onepassworditem_controller.go
+++ b/internal/controller/onepassworditem_controller.go
@@ -162,7 +162,7 @@ func (r *OnePasswordItemReconciler) handleOnePasswordItem(resource *onepasswordv
 	secretName := resource.GetName()
 	labels := resource.Labels
 	secretType := resource.Type
-	autoRestart := resource.Annotations[op.RestartDeploymentsAnnotation]
+	autoRestart := resource.Annotations[op.AutoRestartWorkloadAnnotation]
 
 	item, err := op.GetOnePasswordItemByPath(r.OpConnectClient, resource.Spec.ItemPath)
 	if err != nil {

--- a/pkg/onepassword/annotations.go
+++ b/pkg/onepassword/annotations.go
@@ -8,12 +8,12 @@ import (
 )
 
 const (
-	OnepasswordPrefix            = "operator.1password.io"
-	ItemPathAnnotation           = OnepasswordPrefix + "/item-path"
-	NameAnnotation               = OnepasswordPrefix + "/item-name"
-	VersionAnnotation            = OnepasswordPrefix + "/item-version"
-	RestartAnnotation            = OnepasswordPrefix + "/last-restarted"
-	RestartDeploymentsAnnotation = OnepasswordPrefix + "/auto-restart"
+	OnepasswordPrefix             = "operator.1password.io"
+	ItemPathAnnotation            = OnepasswordPrefix + "/item-path"
+	NameAnnotation                = OnepasswordPrefix + "/item-name"
+	VersionAnnotation             = OnepasswordPrefix + "/item-version"
+	RestartAnnotation             = OnepasswordPrefix + "/last-restarted"
+	AutoRestartWorkloadAnnotation = OnepasswordPrefix + "/auto-restart"
 )
 
 func GetAnnotationsForDeployment(deployment *appsv1.Deployment, regex *regexp.Regexp) (map[string]string, bool) {
@@ -36,7 +36,7 @@ func GetAnnotationsForDeployment(deployment *appsv1.Deployment, regex *regexp.Re
 func FilterAnnotations(annotations map[string]string, regex *regexp.Regexp) map[string]string {
 	filteredAnnotations := make(map[string]string)
 	for key, value := range annotations {
-		if regex.MatchString(key) && key != RestartAnnotation && key != RestartDeploymentsAnnotation {
+		if regex.MatchString(key) && key != RestartAnnotation && key != AutoRestartWorkloadAnnotation {
 			filteredAnnotations[key] = value
 		}
 	}

--- a/pkg/onepassword/deployments.go
+++ b/pkg/onepassword/deployments.go
@@ -11,16 +11,3 @@ func IsDeploymentUsingSecrets(deployment *appsv1.Deployment, secrets map[string]
 	containers = append(containers, deployment.Spec.Template.Spec.InitContainers...)
 	return AreAnnotationsUsingSecrets(deployment.Annotations, secrets) || AreContainersUsingSecrets(containers, secrets) || AreVolumesUsingSecrets(volumes, secrets)
 }
-
-func GetUpdatedSecretsForDeployment(deployment *appsv1.Deployment, secrets map[string]*corev1.Secret) map[string]*corev1.Secret {
-	volumes := deployment.Spec.Template.Spec.Volumes
-	containers := deployment.Spec.Template.Spec.Containers
-	containers = append(containers, deployment.Spec.Template.Spec.InitContainers...)
-
-	updatedSecretsForDeployment := map[string]*corev1.Secret{}
-	AppendAnnotationUpdatedSecret(deployment.Annotations, secrets, updatedSecretsForDeployment)
-	AppendUpdatedContainerSecrets(containers, secrets, updatedSecretsForDeployment)
-	AppendUpdatedVolumeSecrets(volumes, secrets, updatedSecretsForDeployment)
-
-	return updatedSecretsForDeployment
-}

--- a/pkg/onepassword/secret_update_handler_test.go
+++ b/pkg/onepassword/secret_update_handler_test.go
@@ -415,7 +415,7 @@ var tests = []testUpdateSecretTask{
 				Name:      name,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					RestartDeploymentsAnnotation: "false",
+					AutoRestartWorkloadAnnotation: "false",
 				},
 			},
 			Spec: appsv1.DeploymentSpec{
@@ -450,9 +450,9 @@ var tests = []testUpdateSecretTask{
 				Name:      name,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					VersionAnnotation:            "old version",
-					ItemPathAnnotation:           itemPath,
-					RestartDeploymentsAnnotation: "true",
+					VersionAnnotation:             "old version",
+					ItemPathAnnotation:            itemPath,
+					AutoRestartWorkloadAnnotation: "true",
 				},
 			},
 			Data: expectedSecretData,
@@ -463,9 +463,9 @@ var tests = []testUpdateSecretTask{
 				Name:      name,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					VersionAnnotation:            fmt.Sprint(itemVersion),
-					ItemPathAnnotation:           itemPath,
-					RestartDeploymentsAnnotation: "true",
+					VersionAnnotation:             fmt.Sprint(itemVersion),
+					ItemPathAnnotation:            itemPath,
+					AutoRestartWorkloadAnnotation: "true",
 				},
 			},
 			Data: expectedSecretData,
@@ -489,7 +489,7 @@ var tests = []testUpdateSecretTask{
 				Name:      name,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					RestartDeploymentsAnnotation: "true",
+					AutoRestartWorkloadAnnotation: "true",
 				},
 			},
 			Spec: appsv1.DeploymentSpec{
@@ -524,9 +524,9 @@ var tests = []testUpdateSecretTask{
 				Name:      name,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					VersionAnnotation:            "old version",
-					ItemPathAnnotation:           itemPath,
-					RestartDeploymentsAnnotation: "false",
+					VersionAnnotation:             "old version",
+					ItemPathAnnotation:            itemPath,
+					AutoRestartWorkloadAnnotation: "false",
 				},
 			},
 			Data: expectedSecretData,
@@ -537,9 +537,9 @@ var tests = []testUpdateSecretTask{
 				Name:      name,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					VersionAnnotation:            fmt.Sprint(itemVersion),
-					ItemPathAnnotation:           itemPath,
-					RestartDeploymentsAnnotation: "false",
+					VersionAnnotation:             fmt.Sprint(itemVersion),
+					ItemPathAnnotation:            itemPath,
+					AutoRestartWorkloadAnnotation: "false",
 				},
 			},
 			Data: expectedSecretData,
@@ -563,7 +563,7 @@ var tests = []testUpdateSecretTask{
 				Name:      name,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					RestartDeploymentsAnnotation: "true",
+					AutoRestartWorkloadAnnotation: "true",
 				},
 			},
 			Spec: appsv1.DeploymentSpec{
@@ -630,7 +630,7 @@ var tests = []testUpdateSecretTask{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namespace,
 				Annotations: map[string]string{
-					RestartDeploymentsAnnotation: "true",
+					AutoRestartWorkloadAnnotation: "true",
 				},
 			},
 		},
@@ -643,7 +643,7 @@ var tests = []testUpdateSecretTask{
 				Name:      name,
 				Namespace: namespace,
 				Annotations: map[string]string{
-					RestartDeploymentsAnnotation: "false",
+					AutoRestartWorkloadAnnotation: "false",
 				},
 			},
 			Spec: appsv1.DeploymentSpec{
@@ -709,7 +709,7 @@ var tests = []testUpdateSecretTask{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namespace,
 				Annotations: map[string]string{
-					RestartDeploymentsAnnotation: "true",
+					AutoRestartWorkloadAnnotation: "true",
 				},
 			},
 		},
@@ -813,9 +813,9 @@ func TestUpdateSecretHandler(t *testing.T) {
 				return &item, nil
 			}
 			h := &SecretUpdateHandler{
-				client:                             cl,
-				opConnectClient:                    opConnectClient,
-				shouldAutoRestartDeploymentsGlobal: testData.globalAutoRestartEnabled,
+				client:                       cl,
+				opConnectClient:              opConnectClient,
+				autoRestartWorkloadsGlobally: testData.globalAutoRestartEnabled,
 			}
 
 			err := h.UpdateKubernetesSecretsTask()


### PR DESCRIPTION
### Overview

Refactors the auto-restart logic for workloads referencing 1Password-managed secrets. It generalises internal logic to allow future support for non-Deployment workload types (i.e. stateful sets, daemon sets) while preserving existing behaviour.

- All restart logic now operates on `client.Object` or `runtime.Object`
- Tests and helper functions are updated to handle polymorphic workloads
- Sets the foundation for issue-driven expansion to DaemonSets, StatefulSets, etc.

The next steps should this implementation be approved would be to implement controllers for each of the remaining workloads. 

A demo of this implementation working for DaemonSets can be found at: https://github.com/jmsnll/onepassword-operator/tree/feat/demo-daemonsets-autorestart 

### Related Issue(s)
- https://github.com/1Password/onepassword-operator/issues/158
- https://github.com/1Password/onepassword-operator/issues/191

### Changelog

- Refactored workload restart logic to support any client.Object, not just Deployment
- Added helpers:
  - `GetPodTemplate` extracts pod template from known workload types
  - `GetUpdatedSecretsForPodTemplate` resolves updated secrets from a pod spec
- Test struct updated to use `runtime.Object` for workload definitions
- Should preserved full compatibility with existing Deployment-based functionality