### PR TITLE
Fix panic when reading file

### DIFF
--- a/internal/controller/deployment_controller.go
+++ b/internal/controller/deployment_controller.go
@@ -203,13 +203,13 @@ func (r *DeploymentReconciler) handleApplyingDeployment(ctx context.Context, dep
 
 	item, err := op.GetOnePasswordItemByPath(ctx, r.OpClient, annotations[op.ItemPathAnnotation])
 	if err != nil {
-		return fmt.Errorf("Failed to retrieve item: %v", err)
+		return fmt.Errorf("failed to retrieve item: %w", err)
 	}
 
 	// Create owner reference.
 	gvk, err := apiutil.GVKForObject(deployment, r.Scheme)
 	if err != nil {
-		return fmt.Errorf("could not to retrieve group version kind: %v", err)
+		return fmt.Errorf("could not to retrieve group version kind: %w", err)
 	}
 	ownerRef := &metav1.OwnerReference{
 		APIVersion: gvk.GroupVersion().String(),

--- a/internal/controller/onepassworditem_controller.go
+++ b/internal/controller/onepassworditem_controller.go
@@ -173,13 +173,13 @@ func (r *OnePasswordItemReconciler) handleOnePasswordItem(ctx context.Context, r
 
 	item, err := op.GetOnePasswordItemByPath(ctx, r.OpClient, resource.Spec.ItemPath)
 	if err != nil {
-		return fmt.Errorf("Failed to retrieve item: %v", err)
+		return fmt.Errorf("failed to retrieve item: %w", err)
 	}
 
 	// Create owner reference.
 	gvk, err := apiutil.GVKForObject(resource, r.Scheme)
 	if err != nil {
-		return fmt.Errorf("could not to retrieve group version kind: %v", err)
+		return fmt.Errorf("could not to retrieve group version kind: %w", err)
 	}
 	ownerRef := &metav1.OwnerReference{
 		APIVersion: gvk.GroupVersion().String(),

--- a/pkg/kubernetessecrets/kubernetes_secrets_builder.go
+++ b/pkg/kubernetessecrets/kubernetes_secrets_builder.go
@@ -120,7 +120,7 @@ func BuildKubernetesSecretData(fields []model.ItemField, files []model.File) map
 	for _, file := range files {
 		content, err := file.Content()
 		if err != nil {
-			log.Error(err, "Could not load contents of file %s", file.Name)
+			log.Error(err, fmt.Sprintf("Could not load contents of file %s", file.Name))
 			continue
 		}
 		if content != nil {

--- a/pkg/onepassword/client/connect/connect.go
+++ b/pkg/onepassword/client/connect/connect.go
@@ -2,7 +2,9 @@ package connect
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/1Password/connect-sdk-go/connect"
 	"github.com/1Password/connect-sdk-go/onepassword"
@@ -30,7 +32,7 @@ func NewClient(config Config) *Connect {
 func (c *Connect) GetItemByID(ctx context.Context, vaultID, itemID string) (*model.Item, error) {
 	connectItem, err := c.client.GetItemByUUID(itemID, vaultID)
 	if err != nil {
-		return nil, fmt.Errorf("1Password Connect error: %w", err)
+		return nil, fmt.Errorf("GetItemByID 1Password Connect error: %w", err)
 	}
 
 	var item model.Item
@@ -42,7 +44,7 @@ func (c *Connect) GetItemsByTitle(ctx context.Context, vaultID, itemTitle string
 	// Get all items in the vault with the specified title
 	connectItems, err := c.client.GetItemsByTitle(itemTitle, vaultID)
 	if err != nil {
-		return nil, fmt.Errorf("1Password Connect error: %w", err)
+		return nil, fmt.Errorf("GetItemsByTitle 1Password Connect error: %w", err)
 	}
 
 	items := make([]model.Item, len(connectItems))
@@ -55,21 +57,38 @@ func (c *Connect) GetItemsByTitle(ctx context.Context, vaultID, itemTitle string
 	return items, nil
 }
 
+// GetFileContent retrieves the content of a file from a 1Password item.
+// As the Connect has a delay when synchronizing files and returns a 500 error in this case, this function implements a retry mechanism.
 func (c *Connect) GetFileContent(ctx context.Context, vaultID, itemID, fileID string) ([]byte, error) {
-	bytes, err := c.client.GetFileContent(&onepassword.File{
-		ContentPath: fmt.Sprintf("/v1/vaults/%s/items/%s/files/%s/content", vaultID, itemID, fileID),
-	})
-	if err != nil {
-		return nil, fmt.Errorf("1Password Connect error: %w", err)
+	const maxRetries = 5
+	const delay = 1 * time.Second
+
+	var lastErr error
+	for i := 0; i < maxRetries; i++ {
+		bytes, err := c.client.GetFileContent(&onepassword.File{
+			ContentPath: fmt.Sprintf("/v1/vaults/%s/items/%s/files/%s/content", vaultID, itemID, fileID),
+		})
+		if err == nil {
+			return bytes, nil
+		}
+
+		var connectErr *onepassword.Error
+		if errors.As(err, &connectErr) && connectErr.StatusCode == 500 {
+			lastErr = err
+			time.Sleep(delay)
+			continue
+		}
+
+		return nil, fmt.Errorf("GetFileContent 1Password Connect error: %w", err)
 	}
 
-	return bytes, nil
+	return nil, fmt.Errorf("GetFileContent failed after retries: %w", lastErr)
 }
 
 func (c *Connect) GetVaultsByTitle(ctx context.Context, vaultQuery string) ([]model.Vault, error) {
 	connectVaults, err := c.client.GetVaultsByTitle(vaultQuery)
 	if err != nil {
-		return nil, fmt.Errorf("1Password Connect error: %w", err)
+		return nil, fmt.Errorf("GetVaultsByTitle 1Password Connect error: %w", err)
 	}
 
 	var vaults []model.Vault

--- a/pkg/onepassword/items.go
+++ b/pkg/onepassword/items.go
@@ -33,11 +33,12 @@ func GetOnePasswordItemByPath(ctx context.Context, opClient opclient.Client, pat
 		return nil, fmt.Errorf("faield to 'GetItemByID' for vaultID='%s' and itemID='%s': %w", vaultID, itemID, err)
 	}
 
-	for _, file := range item.Files {
-		_, err := opClient.GetFileContent(ctx, vaultID, itemID, file.ID)
+	for i, file := range item.Files {
+		content, err := opClient.GetFileContent(ctx, vaultID, itemID, file.ID)
 		if err != nil {
 			return nil, err
 		}
+		item.Files[i].SetContent(content)
 	}
 
 	return item, nil


### PR DESCRIPTION
Resolves #209 

This PR fixes panic when handling files.

This issue happened because previously `onepassword.GetFileContent` was called directly and under the hood it set file content `file.SetContent(content)`, and after [adding service account support](https://github.com/1Password/onepassword-operator/pull/198/files#diff-c75eea26e30da5450b32ff9db546a834cf98e9ff937836a2df60507f75d4d1bfR36), we should handle it manually now.

This PR also fixes the logging error which caused a panic.


## How to test
1. `minikube start`
2. `eval $(minikube docker-env)`
3. `make docker-build`
4. `export OP_CONNECT_TOKEN=YOUR_TOKEN`
5.  `kubectl create secret generic onepassword-token --from-literal=token=$OP_CONNECT_TOKEN`
6. Install Connect 
```
helm install connect 1password/connect \                                              
  --set connect.create=true \
  --set-file connect.credentials=path_to_credentials_file \
  --set operator.create=false
```
7. `make deploy`
8. `kubectl apply -f ./config/samples/secret.yaml` // make sure to change path to pint to the 1password item containing a file
9. Secret should be created