### PR TITLE
Display READY column

### DIFF
--- a/api/v1/onepassworditem_types.go
+++ b/api/v1/onepassworditem_types.go
@@ -69,6 +69,8 @@ type OnePasswordItemStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 
 // OnePasswordItem is the Schema for the onepassworditems API
 type OnePasswordItem struct {

--- a/config/crd/bases/onepassword.com_onepassworditems.yaml
+++ b/config/crd/bases/onepassword.com_onepassworditems.yaml
@@ -14,7 +14,14 @@ spec:
     singular: onepassworditem
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - jsonPath: .status.conditions[?(@.type=="Ready")].status
+      name: Ready
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: OnePasswordItem is the Schema for the onepassworditems API


### PR DESCRIPTION
This pull request adds additional printer columns to the OnePasswordItem custom resource definition, making it easier to view important status information when using kubectl or k9s etc. 

**Before** 

k9s to display :

<img width="1125" height="79" alt="image" src="https://github.com/user-attachments/assets/b9416b1c-2693-46de-b6ae-4222f417a0a4" />


**Now**

<img width="940" height="70" alt="image" src="https://github.com/user-attachments/assets/fb3b2586-999e-485a-883c-af6a810ec7ca" />

