### PR TITLE
Comment should represent the state of e2e tests

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -100,8 +100,8 @@ jobs:
           issue-number: ${{ github.event.client_payload.pull_request.number }}
           body: |
             ${{ 
-                needs.e2e-test.result == 'success' && '✅ E2E tests passed.' || 
-                needs.e2e-test.result == 'failure' && '❌ E2E tests failed.' || 
+                needs.e2e.result == 'success' && '✅ E2E tests passed.' || 
+                needs.e2e.result == 'failure' && '❌ E2E tests failed.' || 
                 '⚠️ E2E tests completed.'
             }}
 


### PR DESCRIPTION
### ✨ Summary
This PR fixes the comment message which bot puts after at the end of `/ok-to-test` flow.

<!-- What issue does it resolve? -->
### 🔗 Resolves:

### ✅ Checklist
- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit
  - [ ] 🔸 Integration
  - [ ] 🌐 E2E (Connect)
  - [ ] 🔑 E2E (Service Account)
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks
<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
