### PR TITLE
docs: add service account documentation link to USAGEGUIDE

### DIFF
--- a/USAGEGUIDE.md
+++ b/USAGEGUIDE.md
@@ -31,7 +31,9 @@ There are 2 ways 1Password Operator can talk to 1Password servers:
 
 ##  Use Kubernetes Operator with Service Account
 
-### 1. [Create a service account](https://developer.1password.com/docs/service-accounts/get-started#create-a-service-account)
+### 1. Create a service account
+- For instructions on creating and managing Service Accounts, refer to the [official 1Password Service Accounts documentation](https://developer.1password.com/docs/service-accounts/).
+
 ### 2. Create a Kubernetes secret for the Service Account
 - Set `OP_SERVICE_ACCOUNT_TOKEN` environment variable to the service account token you created in the previous step. This token will be used by the operator to access 1Password items.
 - Create Kubernetes secret:


### PR DESCRIPTION
### ✨ Summary
Updates `USAGEGUIDE.md` to include a direct link to the official 1Password Service Accounts documentation in the
“Use Kubernetes Operator with Service Account” section.

This helps users find the authoritative instructions for creating and managing Service Accounts
before configuring the operator.

### 🔗 Resolves
Fixes #206

### ✅ Checklist
- [ ] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated (not applicable — documentation-only change)
  - [ ] 🔹 Unit
  - [ ] 🔸 Integration
  - [ ] 🌐 E2E (Connect)
  - [ ] 🔑 E2E (Service Account)
- [x] 📚 Docs updated (no behavior change)

### 🕵️ Review Notes & ⚠️ Risks
Documentation-only change. No impact on operator behavior.