### PR TITLE
Produce event when error happens in deployment

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -307,6 +307,7 @@ func main() {
 		Scheme:             mgr.GetScheme(),
 		OpClient:           opClient,
 		OpAnnotationRegExp: r,
+		Recorder:           mgr.GetEventRecorderFor("onepassword-operator-deployment"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Deployment")
 		os.Exit(1)

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -198,6 +198,7 @@ var _ = BeforeSuite(func() {
 		Scheme:             k8sManager.GetScheme(),
 		OpClient:           mockOpClient,
 		OpAnnotationRegExp: r,
+		Recorder:           k8sManager.GetEventRecorderFor("onepassword-operator-deployment"),
 	}
 	err = (deploymentReconciler).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
### ✨ Summary
<!-- What does this change do? -->

Currently, `DeploymentReconciler` doesn't show errors in case of 1password item error happens (aka invalid item path that leads to `404` item not found).

That means when user describes the deployment, the `Events` section doesn't show any warning. And it seems the are no errors. Users can only observe the error when exploring operator logs.

This PR makes `DeploymentReconciler` to show a warning event when there is an error returned from 1password server.
<img width="988" height="115" alt="Screenshot 2026-01-15 at 2 02 58 PM" src="https://github.com/user-attachments/assets/c50b9a92-c655-4daf-b152-24800a0fa8e2" />

So it's easier for users to identify the issues with secrets created by the operator.

### Test to reproduce:
1. Follow [testing steps](https://github.com/1Password/onepassword-operator/blob/main/CONTRIBUTING.md#testing) to build and deploy operator locally.
2. use the following `deployment.yaml`
```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: test-deployment-with-secret
  labels:
    app.kubernetes.io/name: test-deployment
    app.kubernetes.io/part-of: onepassword-connect-operator
  annotations:
    # Use an invalid item path
    operator.1password.io/item-path: "vaults/invalid-vault/items/invalid-item"
    operator.1password.io/item-name: "test-secret"
spec:
  replicas: 1
  selector:
    matchLabels:
      app: test-deployment
  template:
    metadata:
      labels:
        app: test-deployment
    spec:
      containers:
        - name: test-container
          image: busybox:latest
          imagePullPolicy: IfNotPresent
          command: ["sleep", "infinity"]

```
3. `kubectl apply -f deployment.yaml`
4. `kubectl describe deployment test-deployment-with-secret`
5. `Events` section should show `Warning` entry with the error
```
  Warning  ReconcileError     7m54s (x18 over 18m)  onepassword-deployment  Failed to sync secret from 1Password: failed to retrieve item: failed to 'getVaultID' for vaultNameOrID='invalid-vault': no vaults found with identifier "invalid-vault"
```

<!-- What issue does it resolve? -->
### 🔗 Resolves: #88

### ✅ Checklist
- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit
  - [ ] 🔸 Integration
  - [ ] 🌐 E2E (Connect)
  - [ ] 🔑 E2E (Service Account)
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks
<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
