### PR TITLE
Skip running e2e tests on release PRs.

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -11,6 +11,10 @@ on:
       - '.gitignore'
       - '.dockerignore'
       - 'LICENSE'
+      - 'version/version.go'
+      - '.VERSION'
+      - 'Makefile'
+      - 'Dockerfile'
   push:
     branches: [main]
     paths-ignore: *ignore_paths


### PR DESCRIPTION
### ✨ Summary
Skip running e2e tests on release PRs, as versions doesn't affect operator logic. But skipping e2e tests from running on release PRs will make release process faster.

<!-- What issue does it resolve? -->
### 🔗 Resolves:

### ✅ Checklist
- [x] 🖊️ Commits are signed
- [ ] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing.md) for when to use each type and how to run them)_
  - [ ] 🔹 Unit
  - [ ] 🔸 Integration
  - [ ] 🌐 E2E (Connect)
  - [ ] 🔑 E2E (Service Account)
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks
<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
