### PR TITLE
Handle incorrect k8s secret data keys

### DIFF
--- a/pkg/kubernetessecrets/kubernetes_secrets_builder_test.go
+++ b/pkg/kubernetessecrets/kubernetes_secrets_builder_test.go
@@ -279,24 +279,34 @@ func TestBuildKubernetesSecretDataWithFieldURLConflict(t *testing.T) {
 	}
 }
 
-func TestBuildKubernetesSecretData_ShouldSkipEmptyLabels(t *testing.T) {
+func TestBuildKubernetesSecretData_InvalidLabels(t *testing.T) {
 	fields := []model.ItemField{
-		{Label: "", Value: "value1"},
+		{Label: "", Value: "empty-label"},
+		{Label: "   ", Value: "whitespace-only"},
+		{Label: "###", Value: "special-chars-only"},
+		{Label: "@@@", Value: "at-signs-only"},
+		{Label: "%%%", Value: "percent-signs-only"},
 	}
 
 	urls := []model.ItemURL{
 		{URL: "https://example.com", Label: "", Primary: true},
+		{URL: "https://test.com", Label: "   ", Primary: false},
+		{URL: "https://other.com", Label: "###", Primary: false},
 	}
 
 	files := []model.File{
-		{Name: "", ContentPath: "content1.txt"},
+		{Name: ""},
+		{Name: "   "},
+		{Name: "###"},
 	}
 	files[0].SetContent([]byte("content1"))
+	files[1].SetContent([]byte("content2"))
+	files[2].SetContent([]byte("content3"))
 
 	secretData := BuildKubernetesSecretData(fields, urls, files)
 
 	if len(secretData) != 0 {
-		t.Errorf("Expected 0 keys, got %d", len(secretData))
+		t.Errorf("Expected 0 keys, got %d: %v", len(secretData), secretData)
 	}
 }
 


### PR DESCRIPTION
### ✨ Summary

K8s throws an error if data key in k8s secret doesn't match `[-._a-zA-Z0-9]+` regexp. ([IsConfigMap](https://pkg.go.dev/k8s.io/apimachinery@v0.35.0/pkg/util/validation#IsConfigMapKey) method).

The empty string `""` keys are considered invalid as well.

In the current implementation `formatSecretDataName` will return empty string if the key (field or url label) contains invalid characters, for example (`####` or `"     "`). Therefore it tries to add the entry into k8s secret.data with key as empty string. This leads operator to throw an error.

This PR fixes this behaviour, and if `formatSecretDataName` returns empty string (aka label was in the format that k8s doesn't support), operator will print the message in the log and skip adding the entry (field, url or file) into k8s secret.


<!-- What issue does it resolve? -->
### 🔗 Resolves: #243 

### ✅ Checklist
- [x] 🖊️ Commits are signed
- [x] 🧪 Tests added/updated: _(See the [Testing Guide](docs/testing.md) for when to use each type and how to run them)_
  - [x] 🔹 Unit
  - [ ] 🔸 Integration
  - [ ] 🌐 E2E (Connect)
  - [ ] 🔑 E2E (Service Account)
- [ ] 📚 Docs updated (if behavior changed)

### 🕵️ Review Notes & ⚠️ Risks
<!-- Notes for reviewers, flags, feature gates, rollout considerations, etc. -->
